### PR TITLE
Polish redesign: home 404s, note colors, palette throughline, mobile touch

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onAuthChange } from '$lib/firebase'
   import { authLoading, authUser, currentPreferences, initPreferencesSync, cleanupPreferencesSync } from '$lib/stores/app'
-  import { currentRoute, navigate, navMode } from '$lib/stores/nav'
+  import { currentRoute, currentPath, navigate, navMode } from '$lib/stores/nav'
   import { initHomeStore, cleanupHomeStore } from '$lib/stores/home'
   import { onMount } from 'svelte'
   import { Toaster } from 'svelte-sonner'
@@ -45,7 +45,7 @@
     })
 
     const handlePopState = () => {
-      currentRoute.set(window.location.pathname)
+      currentRoute.set(window.location.pathname + window.location.search)
     }
     window.addEventListener('popstate', handlePopState)
 
@@ -92,13 +92,14 @@
 
   // Determine library type from path
   let libraryType = $derived.by(() => {
-    if ($currentRoute === '/library/movies') return 'movie' as const
-    if ($currentRoute === '/library/tv') return 'tv' as const
-    if ($currentRoute === '/library/games') return 'game' as const
+    if ($currentPath === '/library/movies') return 'movie' as const
+    if ($currentPath === '/library/tv') return 'tv' as const
+    if ($currentPath === '/library/games') return 'game' as const
     return null
   })
 
   let showSidebar = $derived($navMode === 'sidebar')
+  let showBottomTabs = $derived($navMode === 'bottom-tabs')
 </script>
 
 <Toaster richColors position="bottom-center" />
@@ -121,34 +122,36 @@
   <Login />
 {:else}
   {#if showSidebar}
-    <Sidebar currentPath={$currentRoute} navigate={handleNavigate} />
+    <Sidebar currentPath={$currentPath} navigate={handleNavigate} />
   {/if}
 
   <main
-    class="min-h-screen pb-8 px-4 sm:px-6 transition-all"
+    class="min-h-screen px-4 sm:px-6 transition-all"
+    class:pb-8={!showBottomTabs}
+    class:pb-24={showBottomTabs}
     class:pt-16={showSidebar}
     class:pt-6={!showSidebar}
     class:pt-24={isOffline && showSidebar}
     class:pt-14={isOffline && !showSidebar}
   >
     <div class="max-w-5xl mx-auto">
-      {#if $currentRoute === '/'}
+      {#if $currentPath === '/'}
         <Home navigate={handleNavigate} />
-      {:else if $currentRoute === '/search'}
+      {:else if $currentPath === '/search'}
         <Search navigate={handleNavigate} />
-      {:else if $currentRoute === '/notes'}
+      {:else if $currentPath === '/notes'}
         <Notes />
-      {:else if $currentRoute === '/videos'}
+      {:else if $currentPath === '/videos'}
         <Videos />
-      {:else if $currentRoute === '/profiles'}
+      {:else if $currentPath === '/profiles'}
         <Profiles />
       {:else if libraryType}
         <Library type={libraryType} navigate={handleNavigate} />
-      {:else if $currentRoute === '/places'}
+      {:else if $currentPath === '/places'}
         <Places />
-      {:else if $currentRoute === '/debug'}
+      {:else if $currentPath === '/debug'}
         <Debug />
-      {:else if $currentRoute === '/settings'}
+      {:else if $currentPath === '/settings'}
         <Settings navigate={handleNavigate} />
       {:else}
         <!-- 404 Not Found -->
@@ -171,5 +174,5 @@
 
   <BackToTop />
   <IdentityPill />
-  <BottomTabBar activeRoute={$currentRoute} onNavigate={handleNavigate} />
+  <BottomTabBar activeRoute={$currentPath} onNavigate={handleNavigate} />
 {/if}

--- a/src/app.css
+++ b/src/app.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --color-accent: #6366f1;
+  --color-accent: #e11d48;
   --color-surface: #ffffff;
   --color-surface-2: #f5f5f4;
   --color-bg: #fafaf9;
@@ -81,20 +81,20 @@
 
   /* Card/panel base */
   .card {
-    @apply bg-surface border border-slate-200 dark:border-slate-700 rounded-xl;
+    @apply bg-surface border border-[var(--color-border)] rounded-xl;
   }
 
   /* Form input base */
   .input {
     @apply w-full px-4 py-3 bg-slate-50 dark:bg-slate-800
-           border border-slate-200 dark:border-slate-600 rounded-lg
+           border border-[var(--color-border)] rounded-lg
            text-slate-900 dark:text-slate-100
            focus:outline-none focus:border-accent transition-colors;
   }
 
   .input-sm {
     @apply w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-800
-           border border-slate-200 dark:border-slate-600 rounded-lg
+           border border-[var(--color-border)] rounded-lg
            focus:outline-none focus:border-accent transition-colors;
   }
 
@@ -119,7 +119,8 @@
 
 @layer base {
   body {
-    @apply bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100;
+    background-color: var(--color-bg);
+    color: var(--color-text);
     font-family: var(--font-body, system-ui, sans-serif);
   }
 

--- a/src/lib/accents.ts
+++ b/src/lib/accents.ts
@@ -1,0 +1,22 @@
+// Curated accent palette, harmonized with the warm stone / zinc neutral
+// palette introduced in the v0.2 redesign. Each swatch sits at roughly the
+// 600 tonal level so white text stays legible on it (btn-primary, avatars,
+// pills all render white-on-accent).
+export const ACCENT_PRESETS = [
+    "#e11d48", // rose
+    "#db2777", // pink
+    "#c026d3", // fuchsia
+    "#7c3aed", // violet
+    "#4f46e5", // indigo
+    "#0d9488", // teal
+    "#059669", // emerald
+    "#d97706", // amber
+] as const
+
+// Per-identity defaults: a complementary rose / violet pairing for Z & T.
+export const DEFAULT_ACCENT_Z = "#e11d48" // rose
+export const DEFAULT_ACCENT_T = "#7c3aed" // violet
+
+// Fallback accent used wherever a preference hasn't loaded yet. Keep this in
+// sync with `--color-accent` in app.css.
+export const DEFAULT_ACCENT = DEFAULT_ACCENT_Z

--- a/src/lib/components/BottomTabBar.svelte
+++ b/src/lib/components/BottomTabBar.svelte
@@ -40,7 +40,7 @@
 
 {#if $navMode === 'bottom-tabs'}
   <nav
-    class="fixed bottom-0 left-0 right-0 z-40 bg-surface border-t border-slate-200 dark:border-slate-700 safe-area-bottom"
+    class="fixed bottom-0 left-0 right-0 z-40 bg-surface border-t border-[var(--color-border)] safe-area-bottom"
     aria-label="Main navigation"
   >
     <div class="flex items-stretch h-14">
@@ -71,9 +71,6 @@
       </button>
     </div>
   </nav>
-
-  <!-- Extra bottom padding so content isn't hidden behind tab bar -->
-  <div class="h-14"></div>
 
   <BottomSheet open={moreOpen} onClose={() => { moreOpen = false }} title="More">
     {#snippet children()}

--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
   import { activeUser, displayAbbreviations, userPreferences } from '$lib/stores/app'
   import { hapticLight } from '$lib/haptics'
+  import { DEFAULT_ACCENT } from '$lib/accents'
   import type { UserId } from '$lib/types'
 
   let isExpanded = $state(false)
   let pillEl = $state<HTMLDivElement | null>(null)
 
-  function toggle(): void {
+  // stopPropagation keeps the window click handler from seeing this tap and
+  // immediately collapsing the pill (the toggle re-renders and detaches the
+  // trigger, so an outside-click check would otherwise wrongly fire).
+  function toggle(e: MouseEvent): void {
+    e.stopPropagation()
     isExpanded = !isExpanded
   }
 
-  function selectUser(userId: UserId): void {
+  function selectUser(e: MouseEvent, userId: UserId): void {
+    e.stopPropagation()
     hapticLight()
     activeUser.set(userId)
     isExpanded = false
@@ -37,7 +43,7 @@
   {#if isExpanded}
     <!-- Expanded picker -->
     <div
-      class="flex items-center gap-1 p-1 rounded-full bg-surface border border-slate-200 dark:border-slate-700 shadow-lg"
+      class="flex items-center gap-1 p-1 rounded-full bg-surface border border-[var(--color-border)] shadow-lg"
       role="listbox"
       aria-label="Switch user"
     >
@@ -47,10 +53,10 @@
           type="button"
           role="option"
           aria-selected={$activeUser === userId}
-          class="w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold transition-transform hover:scale-105 touch-manipulation
+          class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold transition-transform hover:scale-105 touch-manipulation
             {$activeUser === userId ? 'ring-2 ring-offset-1 ring-accent' : ''}"
-          style:background-color={prefs?.accentColor ?? '#6366f1'}
-          onclick={() => selectUser(userId)}
+          style:background-color={prefs?.accentColor ?? DEFAULT_ACCENT}
+          onclick={(e) => selectUser(e, userId)}
         >
           {$displayAbbreviations[userId]}
         </button>
@@ -61,8 +67,8 @@
     <button
       type="button"
       aria-label="Switch user"
-      class="w-10 h-10 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-lg transition-transform hover:scale-105 touch-manipulation"
-      style:background-color={$userPreferences[$activeUser]?.accentColor ?? '#6366f1'}
+      class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-lg transition-transform hover:scale-105 touch-manipulation"
+      style:background-color={$userPreferences[$activeUser]?.accentColor ?? DEFAULT_ACCENT}
       onclick={toggle}
     >
       {$displayAbbreviations[$activeUser]}

--- a/src/lib/components/LocationPicker.svelte
+++ b/src/lib/components/LocationPicker.svelte
@@ -120,7 +120,7 @@
 
 <div class="space-y-2">
   {#if value}
-    <div class="flex items-center gap-2 p-2 bg-slate-50 dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-600">
+    <div class="flex items-center gap-2 p-2 bg-slate-50 dark:bg-slate-800 rounded-lg border border-[var(--color-border)]">
       <span class="text-accent"><MapPin size={16} /></span>
       <span class="flex-1 text-sm truncate" title={value.address || `${value.lat.toFixed(4)}, ${value.lng.toFixed(4)}`}>
         {value.address || `${value.lat.toFixed(4)}, ${value.lng.toFixed(4)}`}
@@ -144,7 +144,7 @@
             oninput={handleSearchInput}
             onfocus={() => searchResults.length > 0 && (showDropdown = true)}
             onblur={handleBlur}
-            class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg text-sm focus:outline-none focus:border-accent"
+            class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg text-sm focus:outline-none focus:border-accent"
             {placeholder}
           />
           {#if searching}
@@ -156,7 +156,7 @@
         
         <button
           type="button"
-          class="px-3 py-2 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-sm hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors disabled:opacity-50 flex items-center justify-center"
+          class="px-3 py-2 bg-slate-100 dark:bg-slate-700 border border-[var(--color-border)] rounded-lg text-sm hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors disabled:opacity-50 flex items-center justify-center"
           onclick={detectCurrentLocation}
           disabled={detectingLocation}
           title="Use current location"
@@ -170,7 +170,7 @@
       </div>
       
       {#if showDropdown && searchResults.length > 0}
-        <div class="absolute top-full left-0 right-0 mt-1 bg-surface border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto">
+        <div class="absolute top-full left-0 right-0 mt-1 bg-surface border border-[var(--color-border)] rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto">
           {#each searchResults as result}
             <button
               type="button"

--- a/src/lib/components/MediaDetailModal.svelte
+++ b/src/lib/components/MediaDetailModal.svelte
@@ -199,7 +199,7 @@
               id="media-status"
               value={media.status}
               onchange={(e) => updateStatus(e.currentTarget.value as MediaStatus)}
-              class="w-full p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg"
+              class="w-full p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg"
             >
               {#each statusOptions as status}
                 <option value={status}>{status}</option>
@@ -254,7 +254,7 @@
             
             <!-- Average Rating -->
             {#if getAverageRating(media) !== null}
-              <div class="pt-2 border-t border-slate-200 dark:border-slate-600">
+              <div class="pt-2 border-t border-[var(--color-border)]">
                 <div class="text-xs text-slate-400 mb-0.5">Average</div>
                 <div class="flex items-center gap-2">
                   <div class="flex gap-0.5">
@@ -282,7 +282,7 @@
                 type="date"
                 bind:value={watchDateInput}
                 onchange={updateWatchDate}
-                class="flex-1 p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg"
+                class="flex-1 p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg"
               />
               {#if watchDateInput}
                 <button
@@ -335,7 +335,7 @@
             onblur={updateNotes}
             placeholder="Add your thoughts..."
             rows="2"
-            class="w-full p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg resize-y focus:outline-none focus:border-accent"
+            class="w-full p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg resize-y focus:outline-none focus:border-accent"
           ></textarea>
         </div>
         
@@ -369,7 +369,7 @@
               type="text"
               bind:value={newComment}
               placeholder="Add a comment..."
-              class="flex-1 px-3 py-2.5 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent"
+              class="flex-1 px-3 py-2.5 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
             />
             <button
               type="submit"
@@ -382,7 +382,7 @@
         </div>
         
         <!-- Metadata info -->
-        <div class="text-xs text-slate-400 pt-2 border-t border-slate-200 dark:border-slate-700">
+        <div class="text-xs text-slate-400 pt-2 border-t border-[var(--color-border)]">
           Added by {getDisplayNameForUser(media.createdBy)} · {formatDate(media.createdAt)}
           {#if media.updatedBy}
             · Updated by {getDisplayNameForUser(media.updatedBy)}

--- a/src/lib/components/PlaceDetailModal.svelte
+++ b/src/lib/components/PlaceDetailModal.svelte
@@ -493,7 +493,7 @@
 
             <!-- Average Rating -->
             {#if getPlaceAverageRating(place) !== null}
-              <div class="pt-2 border-t border-slate-200 dark:border-slate-600">
+              <div class="pt-2 border-t border-[var(--color-border)]">
                 <div class="text-xs text-slate-400 mb-0.5">Average</div>
                 <div class="flex items-center gap-2">
                   <div class="flex gap-0.5">
@@ -593,7 +593,7 @@
         </div>
 
         <!-- Metadata info -->
-        <div class="text-xs text-slate-400 pt-2 border-t border-slate-200 dark:border-slate-700">
+        <div class="text-xs text-slate-400 pt-2 border-t border-[var(--color-border)]">
           Added by {getDisplayNameForUser(place.createdBy)} · {formatDate(place.createdAt)}
           {#if place.updatedBy}
             · Updated by {getDisplayNameForUser(place.updatedBy)}

--- a/src/lib/components/PlaceSuggestions.svelte
+++ b/src/lib/components/PlaceSuggestions.svelte
@@ -91,7 +91,7 @@
 
 <div class="mb-6">
   <button
-    class="w-full flex items-center justify-between p-4 bg-surface border border-slate-200 dark:border-slate-700 rounded-xl hover:border-accent transition-colors"
+    class="w-full flex items-center justify-between p-4 bg-surface border border-[var(--color-border)] rounded-xl hover:border-accent transition-colors"
     onclick={() => expanded = !expanded}
   >
     <div class="flex items-center gap-2">
@@ -107,7 +107,7 @@
   </button>
   
   {#if expanded}
-    <div class="mt-2 p-4 bg-surface border border-slate-200 dark:border-slate-700 rounded-xl">
+    <div class="mt-2 p-4 bg-surface border border-[var(--color-border)] rounded-xl">
       {#if !hasLocation}
         <p class="text-sm text-slate-500 dark:text-slate-400 text-center py-4">
           Enable location in <span class="font-medium">Preferences</span> to discover nearby places

--- a/src/lib/components/PreferencesModal.svelte
+++ b/src/lib/components/PreferencesModal.svelte
@@ -6,6 +6,7 @@
   import { getIOSCompatibleImageUrl } from '$lib/ios-images'
   import { Sun, Moon, MapPin, Camera, X, Loader2 } from 'lucide-svelte'
   import { toast } from 'svelte-sonner'
+  import { ACCENT_PRESETS, DEFAULT_ACCENT_Z } from '$lib/accents'
 
   interface Props {
     open: boolean;
@@ -15,7 +16,7 @@
   let { open, onClose }: Props = $props();
 
   let localTheme = $state<Theme>('dark');
-  let localAccentColor = $state('#6366f1');
+  let localAccentColor = $state(DEFAULT_ACCENT_Z);
   let localName = $state('');
   let localProfilePicture = $state<string | undefined>(undefined);
   let uploadingPicture = $state(false);
@@ -30,16 +31,7 @@
   let previousOpen = false;
   let previousUser: 'Z' | 'T' | null = null;
 
-  const presetColors = [
-    '#6366f1', // Indigo
-    '#ec4899', // Pink
-    '#8b5cf6', // Violet
-    '#06b6d4', // Cyan
-    '#10b981', // Emerald
-    '#f59e0b', // Amber
-    '#ef4444', // Red
-    '#3b82f6', // Blue
-  ];
+  const presetColors = ACCENT_PRESETS;
 
   const radiusOptions = [
     { value: 1000, label: '1 km' },
@@ -162,7 +154,7 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div class="bg-surface rounded-xl max-w-md w-full shadow-2xl max-h-[90vh] flex flex-col" onclick={handleModalClick}>
-      <div class="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <div class="flex items-center justify-between p-4 border-b border-[var(--color-border)] shrink-0">
         <h2 class="text-lg font-semibold">Preferences for {$activeUser}</h2>
         <button
           class="w-8 h-8 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center justify-center text-slate-500"
@@ -237,7 +229,7 @@
             id="prefs-display-name"
             type="text"
             bind:value={localName}
-            class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent"
+            class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
             placeholder="Your name"
           />
         </div>
@@ -247,14 +239,14 @@
           <span class="block text-sm font-medium mb-2">Theme</span>
           <div class="flex gap-3">
             <button
-              class="flex-1 py-3 px-4 rounded-lg border-2 transition-all flex items-center justify-center gap-2 {localTheme === 'light' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+              class="flex-1 py-3 px-4 rounded-lg border-2 transition-all flex items-center justify-center gap-2 {localTheme === 'light' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
               onclick={() => localTheme = 'light'}
             >
               <Sun size={20} />
               <span>Light</span>
             </button>
             <button
-              class="flex-1 py-3 px-4 rounded-lg border-2 transition-all flex items-center justify-center gap-2 {localTheme === 'dark' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+              class="flex-1 py-3 px-4 rounded-lg border-2 transition-all flex items-center justify-center gap-2 {localTheme === 'dark' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
               onclick={() => localTheme = 'dark'}
             >
               <Moon size={20} />
@@ -269,7 +261,8 @@
           <div class="flex flex-wrap gap-2 mb-3">
             {#each presetColors as color}
               <button
-                class="w-10 h-10 rounded-full border-2 transition-transform hover:scale-110"
+                type="button"
+                class="touch-sm w-10 h-10 rounded-full border-2 transition-transform hover:scale-110"
                 style:background-color={color}
                 class:border-white={localAccentColor === color}
                 class:border-transparent={localAccentColor !== color}
@@ -292,7 +285,7 @@
             <input
               type="text"
               bind:value={localAccentColor}
-              class="flex-1 px-3 py-2 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg font-mono"
+              class="flex-1 px-3 py-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg font-mono"
               pattern="^#[0-9A-Fa-f]{6}$"
               aria-label="Custom color hex value"
             />
@@ -300,7 +293,7 @@
         </div>
         
         <!-- Location Settings -->
-        <div class="pt-2 border-t border-slate-200 dark:border-slate-700">
+        <div class="pt-2 border-t border-[var(--color-border)]">
           <span class="flex items-center gap-2 text-sm font-medium mb-3">
             <MapPin size={16} />
             Location Settings
@@ -311,19 +304,19 @@
             <span class="block text-xs text-slate-500 dark:text-slate-400 mb-2">Location Mode</span>
             <div class="flex gap-2">
               <button
-                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'off' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'off' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
                 onclick={() => localLocationMode = 'off'}
               >
                 Off
               </button>
               <button
-                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'manual' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'manual' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
                 onclick={() => localLocationMode = 'manual'}
               >
                 Manual
               </button>
               <button
-                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'auto' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+                class="flex-1 py-2 px-3 rounded-lg border-2 text-sm transition-all {localLocationMode === 'auto' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
                 onclick={() => localLocationMode = 'auto'}
               >
                 Auto
@@ -374,7 +367,7 @@
               <select
                 id="prefs-search-radius"
                 bind:value={localSearchRadius}
-                class="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg"
+                class="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg"
               >
                 {#each radiusOptions as opt}
                   <option value={opt.value}>{opt.label}</option>
@@ -385,7 +378,7 @@
         </div>
         
         <!-- Preview -->
-        <div class="p-3 rounded-lg border border-slate-200 dark:border-slate-700">
+        <div class="p-3 rounded-lg border border-[var(--color-border)]">
           <span class="block text-xs text-slate-500 dark:text-slate-400 mb-2">Preview</span>
           <div class="flex items-center gap-3">
             {#if localProfilePicture}
@@ -413,9 +406,9 @@
         </div>
       </div>
       
-      <div class="flex gap-3 p-4 border-t border-slate-200 dark:border-slate-700 shrink-0">
+      <div class="flex gap-3 p-4 border-t border-[var(--color-border)] shrink-0">
         <button
-          class="flex-1 py-2 px-4 rounded-lg border border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+          class="flex-1 py-2 px-4 rounded-lg border border-[var(--color-border)] hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
           onclick={onClose}
         >
           Cancel

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -137,7 +137,7 @@
   <!-- Hamburger button - top left -->
   <button
     type="button"
-    class="flex items-center justify-center w-11 h-11 rounded-xl bg-surface border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 shadow-sm transition-all touch-manipulation"
+    class="flex items-center justify-center w-11 h-11 rounded-xl bg-surface border border-[var(--color-border)] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 shadow-sm transition-all touch-manipulation"
     onclick={toggleSidebar}
     aria-label={isOpen ? 'Close menu' : 'Open menu'}
     aria-expanded={isOpen}
@@ -152,7 +152,7 @@
   <!-- Home button - top right -->
   <button
     type="button"
-    class="flex items-center justify-center w-11 h-11 rounded-xl bg-surface border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 shadow-sm transition-all touch-manipulation {currentPath === '/' ? 'bg-accent text-white border-accent hover:bg-accent/90' : ''}"
+    class="flex items-center justify-center w-11 h-11 rounded-xl bg-surface border border-[var(--color-border)] text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 shadow-sm transition-all touch-manipulation {currentPath === '/' ? 'bg-accent text-white border-accent hover:bg-accent/90' : ''}"
     onclick={() => handleNavigate('/')}
     aria-label="Go home"
   >
@@ -174,7 +174,7 @@
 <!-- Sidebar -->
 <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
 <aside
-  class="fixed top-0 left-0 z-50 h-full w-72 bg-surface border-r border-slate-200 dark:border-slate-700 shadow-2xl transform flex flex-col"
+  class="fixed top-0 left-0 z-50 h-full w-72 bg-surface border-r border-[var(--color-border)] shadow-2xl transform flex flex-col"
   class:-translate-x-full={!isOpen && !isSwiping}
   class:translate-x-0={isOpen && !isSwiping}
   class:transition-transform={!isSwiping}
@@ -189,7 +189,7 @@
   ontouchend={handleTouchEnd}
 >
   <!-- Header with user info -->
-  <header class="p-4 border-b border-slate-200 dark:border-slate-700 safe-area-top">
+  <header class="p-4 border-b border-[var(--color-border)] safe-area-top">
     <button
       type="button"
       class="w-full flex items-center gap-3 p-3 rounded-xl bg-slate-50 dark:bg-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors touch-manipulation"
@@ -251,7 +251,7 @@
 
       <!-- Library sub-items -->
       {#if libraryExpanded}
-        <div class="ml-4 mt-1 space-y-1 border-l-2 border-slate-200 dark:border-slate-700 pl-4">
+        <div class="ml-4 mt-1 space-y-1 border-l-2 border-[var(--color-border)] pl-4">
           {#each libraryItems as item (item.path)}
             <button
               type="button"
@@ -270,7 +270,7 @@
   </nav>
 
   <!-- Footer with settings and logout -->
-  <footer class="p-3 border-t border-slate-200 dark:border-slate-700 space-y-1">
+  <footer class="p-3 border-t border-[var(--color-border)] space-y-1">
     <button
       type="button"
       class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-left transition-colors touch-manipulation {currentPath === '/settings'

--- a/src/lib/components/VideoDetailModal.svelte
+++ b/src/lib/components/VideoDetailModal.svelte
@@ -190,7 +190,7 @@
         tabindex="0"
       >
         <!-- Header -->
-        <div class="flex items-start justify-between p-6 border-b border-slate-200 dark:border-slate-700">
+        <div class="flex items-start justify-between p-6 border-b border-[var(--color-border)]">
           <div class="flex-1 pr-4">
             <h2 class="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-2">
               {video.title}
@@ -210,7 +210,7 @@
         </div>
 
         <!-- Video Embed -->
-        <div class="p-6 border-b border-slate-200 dark:border-slate-700">
+        <div class="p-6 border-b border-[var(--color-border)]">
           <div class="aspect-video bg-slate-900 rounded-lg overflow-hidden mb-4">
             <iframe
               src={getYouTubeEmbedUrl(video.videoId)}
@@ -232,7 +232,7 @@
         </div>
 
         <!-- Status & Watched Date -->
-        <div class="p-6 border-b border-slate-200 dark:border-slate-700 space-y-4">
+        <div class="p-6 border-b border-[var(--color-border)] space-y-4">
           <div>
             <span class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
               Status
@@ -266,7 +266,7 @@
         </div>
 
         <!-- Ratings -->
-        <div class="p-6 border-b border-slate-200 dark:border-slate-700">
+        <div class="p-6 border-b border-[var(--color-border)]">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-4">Ratings</h3>
           
           {#each ALL_USER_IDS as userId}
@@ -296,7 +296,7 @@
           {/each}
 
           {#if getVideoAverageRating(video)}
-            <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700">
+            <div class="mt-4 pt-4 border-t border-[var(--color-border)]">
               <p class="text-sm font-medium text-slate-700 dark:text-slate-300">
                 Average: {getVideoAverageRating(video)?.toFixed(1)} / 5.0
               </p>
@@ -305,7 +305,7 @@
         </div>
 
         <!-- Notes -->
-        <div class="p-6 border-b border-slate-200 dark:border-slate-700">
+        <div class="p-6 border-b border-[var(--color-border)]">
           <label for="notes" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
             Notes
           </label>

--- a/src/lib/components/ui/BottomSheet.svelte
+++ b/src/lib/components/ui/BottomSheet.svelte
@@ -81,7 +81,7 @@
     </div>
 
     {#if title}
-      <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)] flex-shrink-0">
         <h2 id="bottomsheet-title" class="text-base font-semibold text-slate-900 dark:text-slate-100">{title}</h2>
         <button
           type="button"

--- a/src/lib/components/ui/ListItem.svelte
+++ b/src/lib/components/ui/ListItem.svelte
@@ -30,7 +30,7 @@
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
-  class="group flex items-start gap-4 p-4 bg-surface border border-slate-200 dark:border-slate-700 rounded-xl transition-all"
+  class="group flex items-start gap-4 p-4 bg-surface border border-[var(--color-border)] rounded-xl transition-all"
   class:opacity-70={dimmed}
   class:cursor-pointer={onclick}
   class:hover:border-accent={onclick}

--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -60,7 +60,7 @@
       {#if header}
         {@render header()}
       {:else}
-        <header class="shrink-0 border-b border-slate-200 dark:border-slate-700 p-4 flex items-center justify-between">
+        <header class="shrink-0 border-b border-[var(--color-border)] p-4 flex items-center justify-between">
           <h2 id="modal-title" class="text-lg font-bold">{title}</h2>
           <IconButton icon={X} onclick={onclose} label="Close" variant="ghost" size="sm" />
         </header>
@@ -73,7 +73,7 @@
 
       <!-- Footer -->
       {#if footer}
-        <footer class="shrink-0 border-t border-slate-200 dark:border-slate-700 p-4">
+        <footer class="shrink-0 border-t border-[var(--color-border)] p-4">
           {@render footer()}
         </footer>
       {/if}

--- a/src/lib/components/ui/Tabs.svelte
+++ b/src/lib/components/ui/Tabs.svelte
@@ -14,7 +14,7 @@
   let { tabs, active, onchange }: Props = $props()
 </script>
 
-<div class="overflow-x-auto scrollbar-none mb-4 border-b border-slate-200 dark:border-slate-700">
+<div class="overflow-x-auto scrollbar-none mb-4 border-b border-[var(--color-border)]">
   <div class="flex gap-1 min-w-max">
     {#each tabs as tab (tab.key)}
       <button

--- a/src/lib/pages/Debug.svelte
+++ b/src/lib/pages/Debug.svelte
@@ -572,7 +572,7 @@
   </header>
 
   <!-- Data Stats -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <div class="flex items-center gap-2 mb-4">
       <Database size={18} class="text-slate-400" />
       <h2 class="font-semibold">Data Statistics</h2>
@@ -611,7 +611,7 @@
   </section>
 
   <!-- System Info -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <div class="flex items-center gap-2 mb-4">
       <Cpu size={18} class="text-slate-400" />
       <h2 class="font-semibold">System Info</h2>
@@ -636,7 +636,7 @@
   </section>
 
   <!-- Quick Actions -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <h2 class="font-semibold mb-4">Quick Actions</h2>
 
     <div class="flex flex-wrap gap-2">
@@ -670,7 +670,7 @@
   </section>
 
   <!-- Migration Tool -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <h2 class="font-semibold mb-2">Media Migration</h2>
     <p class="text-sm text-slate-500 mb-4">
       Backfill existing media with TMDB genres, collections, and production companies.
@@ -708,7 +708,7 @@
   </section>
 
   <!-- Image Migration Tool -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <div class="flex items-center gap-2 mb-2">
       <Image size={18} class="text-slate-400" />
       <h2 class="font-semibold">Fix Missing Images</h2>
@@ -728,7 +728,7 @@
     <div class="flex flex-wrap items-center gap-3 mb-4">
       <select
         bind:value={imageMigrationType}
-        class="px-3 py-2 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg text-sm"
+        class="px-3 py-2 bg-slate-100 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg text-sm"
         disabled={imageMigrating}
       >
         <option value="all">All Types ({dataStats.missingImages})</option>
@@ -769,7 +769,7 @@
   </section>
 
   <!-- Video Ratings Migration Tool -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <h2 class="font-semibold mb-2">Video Ratings Migration</h2>
     <p class="text-sm text-slate-600 dark:text-slate-400 mb-4">
       Ensures all videos have the proper ratings structure for per-user ratings.
@@ -806,7 +806,7 @@
   </section>
 
   <!-- GitHub Issues -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <div class="flex items-center gap-2 mb-2">
       <GitBranch size={18} class="text-slate-400" />
       <h2 class="font-semibold">GitHub Issues</h2>
@@ -828,7 +828,7 @@
               id="issue-state-filter"
               bind:value={issuesState}
               onchange={loadIssues}
-              class="px-3 py-2 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg text-sm"
+              class="px-3 py-2 bg-slate-100 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg text-sm"
             >
               <option value="all">All Issues</option>
               <option value="open">Open</option>
@@ -923,7 +923,7 @@
                 type="text"
                 bind:value={newIssueTitle}
                 placeholder="Issue title"
-                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent"
+                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
               />
             </div>
 
@@ -934,7 +934,7 @@
                 bind:value={newIssueBody}
                 placeholder="Describe the issue..."
                 rows="6"
-                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent resize-none"
+                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent resize-none"
               ></textarea>
             </div>
 
@@ -1027,7 +1027,7 @@
             </div>
 
             <!-- Comments Section -->
-            <div class="border-t border-slate-200 dark:border-slate-700 pt-4">
+            <div class="border-t border-[var(--color-border)] pt-4">
               <h4 class="font-semibold mb-3">
                 Comments ({issueComments.length})
               </h4>
@@ -1057,7 +1057,7 @@
                   bind:value={newCommentBody}
                   placeholder="Add a comment..."
                   rows="3"
-                  class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent resize-none text-sm"
+                  class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent resize-none text-sm"
                 ></textarea>
                 <button
                   type="button"
@@ -1101,7 +1101,7 @@
                 type="text"
                 bind:value={editIssueTitle}
                 placeholder="Issue title"
-                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent"
+                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
               />
             </div>
 
@@ -1112,7 +1112,7 @@
                 bind:value={editIssueBody}
                 placeholder="Describe the issue..."
                 rows="6"
-                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg focus:outline-none focus:border-accent resize-none"
+                class="w-full px-3 py-2 bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent resize-none"
               ></textarea>
             </div>
 
@@ -1146,7 +1146,7 @@
   </section>
 
   <!-- Current Preferences -->
-  <section class="bg-surface border border-slate-200 dark:border-slate-700 rounded-xl p-4">
+  <section class="bg-surface border border-[var(--color-border)] rounded-xl p-4">
     <h2 class="font-semibold mb-2">Current Preferences</h2>
     <pre class="bg-slate-900 text-slate-300 p-3 rounded-lg font-mono text-xs overflow-x-auto">{JSON.stringify($currentPreferences, null, 2)}</pre>
   </section>

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -704,7 +704,7 @@
       <div class="grid gap-4" style="grid-template-columns: repeat({columns}, minmax(0, 1fr));" role="grid">
         {#each filteredMedia as item, index (item.id)}
           <div
-            class="group relative bg-surface border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden hover:shadow-lg focus:ring-2 focus:ring-accent focus:outline-none transition-all"
+            class="group relative bg-surface border border-[var(--color-border)] rounded-xl overflow-hidden hover:shadow-lg focus:ring-2 focus:ring-accent focus:outline-none transition-all"
             tabindex="0"
             role="gridcell"
             data-grid-item

--- a/src/lib/pages/Login.svelte
+++ b/src/lib/pages/Login.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <div class="flex items-center justify-center min-h-screen">
-  <div class="bg-surface p-12 rounded-2xl text-center border border-slate-200 dark:border-slate-700">
+  <div class="bg-surface p-12 rounded-2xl text-center border border-[var(--color-border)]">
     <h1 class="text-4xl font-bold mb-2 text-accent">Us</h1>
     <p class="text-slate-500 dark:text-slate-400 mb-8">Sign in to continue</p>
 

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -6,6 +6,7 @@
   import { addDocument, deleteDocument, subscribeToCollection, updateDocument } from '$lib/firebase'
   import { hapticLight, hapticMedium, hapticSuccess } from '$lib/haptics'
   import { activeUser, displayNames } from '$lib/stores/app'
+  import { consumeQueryParam } from '$lib/stores/nav'
   import type { Note, NoteColor, UserId } from '$lib/types'
   import { Timestamp, type Timestamp as TimestampType } from 'firebase/firestore'
   import { Archive, ArchiveRestore, Check, Image as ImageIcon, Pencil, Pin, StickyNote, Trash2, X } from 'lucide-svelte'
@@ -45,6 +46,9 @@
   }
 
   onMount(() => {
+    // Open the compose form directly when arriving via a quick-add link.
+    if (consumeQueryParam('add') !== null) composing = true
+
     unsubscribe = subscribeToCollection<Note>('notes', (items) => {
       notes = items
     })
@@ -272,14 +276,15 @@
 
       <!-- Compose sticky inline -->
       {#if composing}
-        <div class="compose-sticky note-yellow">
+        <div class="compose-sticky note-{newNote.color}">
           <div class="sticky-top-tape"></div>
           <div class="p-4 pt-5 space-y-2">
             <div class="flex items-center justify-between mb-1">
-              <span class="text-xs font-semibold text-amber-800/70 uppercase tracking-wider">New note</span>
+              <span class="text-xs font-semibold uppercase tracking-wider" style="color: rgba(0,0,0,0.55)">New note</span>
               <button
                 type="button"
-                class="text-amber-700/60 hover:text-amber-900 transition-colors"
+                class="transition-colors"
+                style="color: rgba(0,0,0,0.5)"
                 onclick={() => { composing = false; newNote = { title: '', content: '', color: 'yellow' }; }}
               >
                 <X size={16} />
@@ -300,12 +305,12 @@
 
             <!-- Color picker -->
             <div class="flex items-center gap-2 pt-1">
-              <span class="text-xs text-amber-700/60">Color:</span>
+              <span class="text-xs" style="color: rgba(0,0,0,0.5)">Color:</span>
               <div class="flex gap-1.5">
                 {#each NOTE_COLORS as color}
                   <button
                     type="button"
-                    class="color-swatch note-{color} {newNote.color === color ? 'ring-2 ring-slate-600 ring-offset-1' : ''}"
+                    class="touch-sm color-swatch note-{color} {newNote.color === color ? 'ring-2 ring-slate-600 ring-offset-1' : ''}"
                     onclick={() => newNote.color = color}
                     aria-label="Color {color}"
                   ></button>
@@ -562,7 +567,7 @@
       {/if}
 
       <!-- Actions row -->
-      <div class="flex items-center gap-2 pt-2 border-t border-slate-200 dark:border-slate-700">
+      <div class="flex items-center gap-2 pt-2 border-t border-[var(--color-border)]">
         <button
           type="button"
           class="btn-secondary text-sm flex-1"
@@ -629,7 +634,7 @@
           {#each NOTE_COLORS as color}
             <button
               type="button"
-              class="color-swatch-lg note-{color} {editingNote.color === color ? 'ring-2 ring-slate-600 ring-offset-2' : ''}"
+              class="touch-sm color-swatch-lg note-{color} {editingNote.color === color ? 'ring-2 ring-slate-600 ring-offset-2' : ''}"
               onclick={() => { if (editingNote) editingNote.color = color }}
               aria-label="Color {color}"
             ></button>
@@ -775,7 +780,7 @@
     width: 0.5rem;
     height: 0.5rem;
     border-radius: 50%;
-    background: #6366f1;
+    background: var(--color-accent);
     box-shadow: 0 0 0 2px white;
   }
 
@@ -815,7 +820,7 @@
   }
 
   .thumbtack-pinned .thumbtack-head {
-    background: radial-gradient(circle at 35% 35%, #a5b4fc, #6366f1);
+    background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.7), var(--color-accent));
   }
 
   .thumbtack-stem {
@@ -1037,7 +1042,7 @@
     width: 0.5rem;
     height: 0.5rem;
     border-radius: 50%;
-    background: #6366f1;
+    background: var(--color-accent);
     box-shadow: 0 0 0 1.5px white;
   }
 </style>

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -19,6 +19,7 @@
   import type { ComponentType } from 'svelte'
   import { hapticSuccess, hapticLight } from '$lib/haptics'
   import { forceRepaint } from '$lib/pwa-utils'
+  import { consumeQueryParam } from '$lib/stores/nav'
 
   const categoryIcons: Record<PlaceCategory, ComponentType> = {
     restaurant: UtensilsCrossed,
@@ -65,6 +66,9 @@
   ]
 
   onMount(() => {
+    // Open the add-place form directly when arriving via a quick-add link.
+    if (consumeQueryParam('add') !== null) showForm = true
+
     unsubscribe = subscribeToCollection<Place>('places', (items) => {
       places = items
       // Keep selected place in sync
@@ -537,7 +541,7 @@
               type="button"
               class="w-11 h-11 rounded-xl border-2 flex items-center justify-center transition-colors touch-manipulation {place.visited
                 ? 'bg-emerald-500 border-emerald-500 text-white'
-                : 'bg-transparent border-slate-200 dark:border-slate-600 text-slate-400 hover:border-emerald-500 hover:text-emerald-500'}"
+                : 'bg-transparent border-[var(--color-border)] text-slate-400 hover:border-emerald-500 hover:text-emerald-500'}"
               onclick={(e) => { e.stopPropagation(); toggleVisited(place); }}
               aria-label={place.visited ? 'Mark as not visited' : 'Mark as visited'}
             >
@@ -546,7 +550,7 @@
 
             <button
               type="button"
-              class="w-11 h-11 rounded-xl border border-slate-200 dark:border-slate-600 flex items-center justify-center text-slate-400 hover:text-red-500 hover:border-red-500 transition-colors opacity-0 group-hover:opacity-100 touch-manipulation"
+              class="w-11 h-11 rounded-xl border border-[var(--color-border)] flex items-center justify-center text-slate-400 hover:text-red-500 hover:border-red-500 transition-colors opacity-0 group-hover:opacity-100 touch-manipulation"
               onclick={(e) => { e.stopPropagation(); place.id && remove(place.id); }}
               aria-label="Remove place"
             >

--- a/src/lib/pages/Search.svelte
+++ b/src/lib/pages/Search.svelte
@@ -18,6 +18,7 @@
   import { Timestamp } from 'firebase/firestore'
   import { searchMovies, searchTV, type TMDBSearchResult } from '$lib/tmdb'
   import { searchGames, type WikiGameResult, fetchGameThumbnail } from '$lib/wikipedia'
+  import { consumeQueryParam } from '$lib/stores/nav'
 
   interface Props {
     navigate: (path: string) => void
@@ -69,6 +70,9 @@
   let unsubPlaces: (() => void) | undefined
 
   onMount(() => {
+    // Switch straight to Discover when arriving via a quick-add link.
+    if (consumeQueryParam('discover') !== null) searchMode = 'discover'
+
     // Load tips preference
     try {
       const stored = localStorage.getItem('search-tips-visible')
@@ -563,7 +567,7 @@
         bind:this={searchInput}
         bind:value={searchQuery}
         placeholder={searchMode === 'library' ? 'Search your library...' : 'Search movies, TV & games...'}
-        class="w-full px-5 py-4 pl-12 pr-12 bg-surface border border-slate-200 dark:border-slate-700 rounded-2xl text-slate-900 dark:text-slate-100 text-lg focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-all"
+        class="w-full px-5 py-4 pl-12 pr-12 bg-surface border border-[var(--color-border)] rounded-2xl text-slate-900 dark:text-slate-100 text-lg focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-all"
       />
       {#if isSearching}
         <Loader2 class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-accent animate-spin" />

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -8,6 +8,7 @@
   import { Camera, Info, Loader2, LogOut, MapPin, Moon, Palette, RefreshCw, Settings, Sun, User, Video, X, Download, ExternalLink as ExternalLinkIcon, Layout, Type } from 'lucide-svelte'
   import { toast } from 'svelte-sonner'
   import { isYouTubeAPIConfigured, requestAccessToken } from '$lib/services/youtube-sync'
+  import { ACCENT_PRESETS, DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from '$lib/accents'
 
   interface Props {
     navigate: (path: string) => void
@@ -17,7 +18,7 @@
 
   // Local state for form
   let localTheme = $state<Theme>('dark')
-  let localAccentColor = $state('#6366f1')
+  let localAccentColor = $state(DEFAULT_ACCENT_Z)
   let localName = $state('')
   let localProfilePicture = $state<string | undefined>(undefined)
   let uploadingPicture = $state(false)
@@ -55,10 +56,7 @@
     }
   })
 
-  const presetColors = [
-    '#6366f1', '#ec4899', '#8b5cf6', '#06b6d4',
-    '#10b981', '#f59e0b', '#ef4444', '#3b82f6',
-  ]
+  const presetColors = ACCENT_PRESETS
 
   // Dynamic radius options based on unit system
   const radiusOptions = $derived(localUnitSystem === 'imperial' ? [
@@ -396,13 +394,13 @@
       <div class="flex gap-2">
         <button
           type="button"
-          class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-3 touch-manipulation {$activeUser === 'Z' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+          class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-3 touch-manipulation {$activeUser === 'Z' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
           onclick={() => handleUserSwitch('Z')}
         >
           {#if $userPreferences.Z?.profilePicture}
             <img src={$userPreferences.Z.profilePicture} alt={$displayAbbreviations.Z} class="w-8 h-8 rounded-full object-cover" />
           {:else}
-            <div class="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-semibold" style:background-color={$userPreferences.Z?.accentColor || '#6366f1'}>
+            <div class="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-semibold" style:background-color={$userPreferences.Z?.accentColor || DEFAULT_ACCENT_Z}>
               {$displayAbbreviations.Z}
             </div>
           {/if}
@@ -410,13 +408,13 @@
         </button>
         <button
           type="button"
-          class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-3 touch-manipulation {$activeUser === 'T' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+          class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-3 touch-manipulation {$activeUser === 'T' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
           onclick={() => handleUserSwitch('T')}
         >
           {#if $userPreferences.T?.profilePicture}
             <img src={$userPreferences.T.profilePicture} alt={$displayAbbreviations.T} class="w-8 h-8 rounded-full object-cover" />
           {:else}
-            <div class="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-semibold" style:background-color={$userPreferences.T?.accentColor || '#ec4899'}>
+            <div class="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm font-semibold" style:background-color={$userPreferences.T?.accentColor || DEFAULT_ACCENT_T}>
               {$displayAbbreviations.T}
             </div>
           {/if}
@@ -502,7 +500,7 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localTheme === 'light' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localTheme === 'light' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleThemeChange('light')}
           >
             <Sun size={20} />
@@ -510,7 +508,7 @@
           </button>
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localTheme === 'dark' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localTheme === 'dark' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleThemeChange('dark')}
           >
             <Moon size={20} />
@@ -526,7 +524,7 @@
           {#each presetColors as color}
             <button
               type="button"
-              class="w-10 h-10 rounded-full border-2 transition-transform hover:scale-110 touch-manipulation"
+              class="touch-sm w-10 h-10 rounded-full border-2 transition-transform hover:scale-110 touch-manipulation"
               style:background-color={color}
               class:border-white={localAccentColor === color}
               class:border-transparent={localAccentColor !== color}
@@ -545,7 +543,7 @@
             type="color"
             bind:value={localAccentColor}
             onchange={() => handleColorChange(localAccentColor)}
-            class="w-10 h-10 rounded cursor-pointer border-0"
+            class="w-11 h-11 rounded cursor-pointer border-0"
           />
           <input
             type="text"
@@ -571,14 +569,14 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localUnitSystem === 'metric' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localUnitSystem === 'metric' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleUnitSystemChange('metric')}
           >
             <span>Metric (km)</span>
           </button>
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localUnitSystem === 'imperial' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex items-center justify-center gap-2 touch-manipulation {localUnitSystem === 'imperial' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleUnitSystemChange('imperial')}
           >
             <span>Imperial (mi)</span>
@@ -599,21 +597,21 @@
         <div class="flex gap-2">
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'off' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'off' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleLocationModeChange('off')}
           >
             Off
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'manual' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'manual' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleLocationModeChange('manual')}
           >
             Manual
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'auto' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localLocationMode === 'auto' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleLocationModeChange('auto')}
           >
             Auto
@@ -661,21 +659,21 @@
         <div class="flex gap-2">
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'none' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'none' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleVideoSyncPlatformChange('none')}
           >
             None
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'youtube' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'youtube' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleVideoSyncPlatformChange('youtube')}
           >
             YouTube
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'grayjay' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localVideoSyncPlatform === 'grayjay' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleVideoSyncPlatformChange('grayjay')}
           >
             Grayjay
@@ -771,21 +769,21 @@
         <div class="flex gap-2">
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'bottom-tabs' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'bottom-tabs' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleNavModeChange('bottom-tabs')}
           >
             Bottom tabs
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'sidebar' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'sidebar' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleNavModeChange('sidebar')}
           >
             Sidebar
           </button>
           <button
             type="button"
-            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'none' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-2.5 px-3 rounded-xl border-2 text-sm transition-all touch-manipulation {localNavMode === 'none' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleNavModeChange('none')}
           >
             None
@@ -806,7 +804,7 @@
         <div class="flex gap-3">
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex flex-col items-center gap-1 touch-manipulation {localFontPreset === 'warm-rounded' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex flex-col items-center gap-1 touch-manipulation {localFontPreset === 'warm-rounded' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleFontPresetChange('warm-rounded')}
           >
             <span class="font-medium text-base" style="font-family: Nunito, system-ui">Aa</span>
@@ -814,7 +812,7 @@
           </button>
           <button
             type="button"
-            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex flex-col items-center gap-1 touch-manipulation {localFontPreset === 'refined-system' ? 'border-accent bg-accent/10' : 'border-slate-200 dark:border-slate-700'}"
+            class="flex-1 py-3 px-4 rounded-xl border-2 transition-all flex flex-col items-center gap-1 touch-manipulation {localFontPreset === 'refined-system' ? 'border-accent bg-accent/10' : 'border-[var(--color-border)]'}"
             onclick={() => handleFontPresetChange('refined-system')}
           >
             <span class="font-medium text-base" style="font-family: system-ui">Aa</span>

--- a/src/lib/pages/Videos.svelte
+++ b/src/lib/pages/Videos.svelte
@@ -275,7 +275,7 @@
 
 <div class="min-h-screen bg-slate-50 dark:bg-slate-900">
   <!-- Header -->
-  <div class="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-10">
+  <div class="bg-white dark:bg-slate-800 border-b border-[var(--color-border)] sticky top-0 z-10">
     <div class="max-w-7xl mx-auto px-4 py-4">
       <div class="flex items-center justify-between mb-4">
         <div class="flex items-center gap-3">
@@ -308,7 +308,7 @@
               </button>
               
               {#if showExportMenu}
-                <div class="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 overflow-hidden z-10">
+                <div class="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-[var(--color-border)] overflow-hidden z-10">
                   <button
                     onclick={handleExportJSON}
                     class="w-full px-4 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
@@ -395,7 +395,7 @@
     {:else}
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {#each filteredVideos as video (video.id)}
-          <div class="bg-white dark:bg-slate-800 rounded-lg overflow-hidden shadow-sm border border-slate-200 dark:border-slate-700 hover:shadow-md transition-shadow">
+          <div class="bg-white dark:bg-slate-800 rounded-lg overflow-hidden shadow-sm border border-[var(--color-border)] hover:shadow-md transition-shadow">
             <!-- Thumbnail -->
             <button
               onclick={() => openVideoDetail(video)}

--- a/src/lib/pages/home/RecentActivityFeed.svelte
+++ b/src/lib/pages/home/RecentActivityFeed.svelte
@@ -50,7 +50,7 @@
         <li>
           <button
             type="button"
-            class="w-full flex items-center gap-3 px-3 py-3 rounded-xl bg-surface border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors touch-manipulation text-left"
+            class="w-full flex items-center gap-3 px-3 py-3 rounded-xl bg-surface border border-[var(--color-border)] hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors touch-manipulation text-left"
             onclick={() => onItemClick(item)}
           >
             {#if item.posterPath}

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -6,6 +6,7 @@ import {
     subscribeToPreferences,
 } from "../firebase"
 import type { UserId, UserPreferences, UserPreferencesMap } from "../types"
+import { DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from "../accents"
 
 // Touch device detection store
 // Uses pointer: coarse media query which is more reliable than touch event detection
@@ -32,7 +33,7 @@ export const isTouchDevice = readable(false, set => {
 const DEFAULT_PREFERENCES: UserPreferencesMap = {
     Z: {
         theme: "dark",
-        accentColor: "#6366f1",
+        accentColor: DEFAULT_ACCENT_Z,
         name: "Z",
         unitSystem: "metric",
         locationMode: "off",
@@ -42,7 +43,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
     },
     T: {
         theme: "light",
-        accentColor: "#ec4899",
+        accentColor: DEFAULT_ACCENT_T,
         name: "T",
         unitSystem: "metric",
         locationMode: "off",

--- a/src/lib/stores/nav.ts
+++ b/src/lib/stores/nav.ts
@@ -2,9 +2,17 @@ import { derived, writable } from "svelte/store"
 import { currentPreferences } from "./app"
 import type { NavMode, UserPreferences } from "../types"
 
-export const currentRoute = writable<string>(
-    typeof window !== "undefined" ? window.location.pathname : "/"
-)
+function currentLocation(): string {
+    if (typeof window === "undefined") return "/"
+    return window.location.pathname + window.location.search
+}
+
+// Full location string, including any query params (e.g. "/notes?add=1").
+export const currentRoute = writable<string>(currentLocation())
+
+// Pathname only, with the query string stripped. Route matching should always
+// use this so that intent params like "?add=1" don't cause a 404.
+export const currentPath = derived(currentRoute, ($route: string) => $route.split("?")[0])
 
 function defaultNavMode(): NavMode {
     if (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) {
@@ -30,4 +38,20 @@ export function goBack(): void {
     if (typeof window !== "undefined") {
         window.history.back()
     }
+}
+
+// Read a query param, then strip it from the URL (via replaceState so no extra
+// history entry is created). Pages use this in onMount to act on navigation
+// intents such as "?add=1" / "?discover=1" and then clean up the address bar.
+export function consumeQueryParam(key: string): string | null {
+    if (typeof window === "undefined") return null
+    const url = new URL(window.location.href)
+    const value = url.searchParams.get(key)
+    if (value !== null) {
+        url.searchParams.delete(key)
+        const cleaned = url.pathname + (url.search ? url.search : "")
+        window.history.replaceState({}, "", cleaned)
+        currentRoute.set(cleaned)
+    }
+    return value
 }


### PR DESCRIPTION
Addresses the batch of issues flagged after the v0.2 redesign.

## Home page buttons lead to 404
The quick-add buttons navigated to `/notes?add=1`, `/places?add=1`, `/search?discover=1`, but routing matched routes with exact string equality (`$currentRoute === '/notes'`), so the query string caused a fall-through to the 404 page. The query params were also never consumed.

- Added a `currentPath` derived store (pathname with the query string stripped); all route matching in `App.svelte`, `Sidebar`, and `BottomTabBar` now uses it.
- `popstate` now preserves the query string.
- Added `consumeQueryParam()` — Notes, Places, and Search read `?add=1` / `?discover=1` on mount to open the compose/discover flow, then clean the param out of the URL via `replaceState`.

## Notes colors stretched / not updating while drafting
- The compose sticky was hardcoded to `note-yellow`; it now uses `note-{newNote.color}` so the background updates live as you pick a color while drafting.
- The small color swatch buttons were being stretched into tall ovals by the global `@media (pointer: coarse)` `min-height: 44px` rule. They're now exempted via the existing `touch-sm` class (compose + edit modal, plus the Settings/PreferencesModal accent swatches).
- The compose form's hardcoded amber text was swapped for neutral black-alpha so it reads on every note color.

## Baseline accent colors inconsistent with the new palette
- Added a shared, warm-harmonized accent palette in `src/lib/accents.ts`, replacing the harsh saturated `500`-level defaults. Used by Settings, PreferencesModal, and the Z/T preference defaults.
- Default accent is now rose (`#e11d48`); Z/T default to a complementary rose/violet pairing.
- The warm stone/zinc tokens the redesign defined but never used (`--color-bg`, `--color-text`, `--color-border`) now actually drive the body background/text and all card/input borders app-wide, so the new palette is visible instead of the old cool slate.
- Note pin/unread accents now reference `--color-accent`.

## Mobile sizing / touch events not registering as clicks
- Content near the bottom of every page was covered by the fixed bottom tab bar (a stray spacer sat at the end of the body instead of padding the content), so taps there hit the tab bar. `main` now gets bottom padding in bottom-tabs mode.
- The IdentityPill collapsed on the same tap that opened it — the window outside-click handler fired on the opening tap (the trigger detaches during the toggle re-render, failing the `contains` check). Fixed by stopping propagation on the toggle/select taps.
- Small avatar/swatch tap targets sized to 44px.

## Verification
- `bun run check` — 0 errors, 0 warnings
- `bun run build` — succeeds
- `bun test:run` — 253 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_