### PR TITLE
Cozy notes system: per-identity palettes, corkboard page, filters, accessibility settings

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,11 +67,13 @@
   let prevTheme: string | undefined = undefined
   let prevAccentColor: string | undefined = undefined
   let prevFontPreset: string | undefined = undefined
+  let prevFontScale: number | undefined = undefined
+  let prevReduceMotion: boolean | undefined = undefined
 
   $effect(() => {
     if ($currentPreferences) {
       const root = document.documentElement
-      const { theme, accentColor, fontPreset } = $currentPreferences
+      const { theme, accentColor, fontPreset, fontScale, reduceMotion } = $currentPreferences
 
       if (prevTheme !== theme) {
         root.classList.toggle('dark', theme === 'dark')
@@ -86,6 +88,18 @@
       if (prevFontPreset !== fontPreset) {
         root.setAttribute('data-font', fontPreset ?? 'warm-rounded')
         prevFontPreset = fontPreset
+      }
+
+      const scale = fontScale ?? 1
+      if (prevFontScale !== scale) {
+        root.style.setProperty('--font-scale', String(scale))
+        prevFontScale = scale
+      }
+
+      const reduce = reduceMotion ?? false
+      if (prevReduceMotion !== reduce) {
+        root.toggleAttribute('data-reduce-motion', reduce)
+        prevReduceMotion = reduce
       }
     }
   })

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -187,6 +187,8 @@
   </main>
 
   <BackToTop />
-  <IdentityPill />
+  {#if $currentPreferences?.showIdentityPill ?? true}
+    <IdentityPill />
+  {/if}
   <BottomTabBar activeRoute={$currentPath} onNavigate={handleNavigate} />
 {/if}

--- a/src/app.css
+++ b/src/app.css
@@ -79,9 +79,10 @@
            transition-colors touch-manipulation disabled:opacity-50;
   }
 
-  /* Card/panel base */
+  /* Card/panel base — softly rounded and gently lifted for a cozier,
+     less flat/"SaaS" feel. */
   .card {
-    @apply bg-surface border border-[var(--color-border)] rounded-xl;
+    @apply bg-surface border border-[var(--color-border)] rounded-2xl shadow-sm;
   }
 
   /* Form input base */
@@ -118,6 +119,13 @@
 }
 
 @layer base {
+  /* Global text/UI scale. Multiplies the viewer's own root size (respecting
+     their browser font preference) by the per-user --font-scale setting. */
+  html {
+    font-size: calc(100% * var(--font-scale, 1));
+    overscroll-behavior-y: contain;
+  }
+
   body {
     background-color: var(--color-bg);
     color: var(--color-text);
@@ -128,11 +136,29 @@
   * {
     -webkit-overflow-scrolling: touch;
   }
+}
 
-  /* Prevent pull-to-refresh in PWA */
-  html {
-    overscroll-behavior-y: contain;
-  }
+/* Reduce-motion: honor the explicit per-user toggle by neutralizing
+   non-essential transitions and animations app-wide. Loading spinners are
+   exempted (they carry meaning), and interactive tap-scale is flattened. */
+:root[data-reduce-motion] *,
+:root[data-reduce-motion] *::before,
+:root[data-reduce-motion] *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+  scroll-behavior: auto !important;
+}
+
+:root[data-reduce-motion] .animate-spin {
+  animation-duration: 0.8s !important;
+  animation-iteration-count: infinite !important;
+}
+
+:root[data-reduce-motion] button:active,
+:root[data-reduce-motion] [role="button"]:active,
+:root[data-reduce-motion] .touch-feedback:active {
+  transform: none !important;
 }
 
 /* Touch device enhancements */

--- a/src/lib/color.test.ts
+++ b/src/lib/color.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest"
+import {
+    normalizeHex,
+    hexToRgb,
+    hexToHsl,
+    hslToHex,
+    readableInk,
+    shiftHue,
+    hueDistance,
+    relativeLuminance,
+} from "./color"
+
+describe("color utilities", () => {
+    describe("normalizeHex", () => {
+        it("expands 3-digit hex", () => {
+            expect(normalizeHex("#abc")).toBe("#aabbcc")
+        })
+        it("lowercases and adds hash", () => {
+            expect(normalizeHex("E11D48")).toBe("#e11d48")
+        })
+        it("rejects invalid input", () => {
+            expect(normalizeHex("nope")).toBeNull()
+            expect(normalizeHex("#12")).toBeNull()
+        })
+    })
+
+    describe("hexToRgb", () => {
+        it("parses channels", () => {
+            expect(hexToRgb("#ff8000")).toEqual({ r: 255, g: 128, b: 0 })
+        })
+    })
+
+    describe("hexToHsl / hslToHex round trip", () => {
+        it("round-trips saturated colors within tolerance", () => {
+            for (const hex of ["#e11d48", "#7c3aed", "#0d9488", "#3b82f6", "#10b981"]) {
+                const back = hslToHex(hexToHsl(hex))
+                const a = hexToRgb(hex)
+                const b = hexToRgb(back)
+                expect(Math.abs(a.r - b.r)).toBeLessThanOrEqual(2)
+                expect(Math.abs(a.g - b.g)).toBeLessThanOrEqual(2)
+                expect(Math.abs(a.b - b.b)).toBeLessThanOrEqual(2)
+            }
+        })
+        it("handles greyscale (zero saturation)", () => {
+            expect(hexToHsl("#000000").l).toBe(0)
+            expect(hexToHsl("#ffffff").l).toBe(100)
+            expect(hexToHsl("#808080").s).toBe(0)
+        })
+    })
+
+    describe("readableInk", () => {
+        it("returns dark ink on light backgrounds", () => {
+            expect(readableInk("#fef08a")).toBe("#1c1917")
+        })
+        it("returns light ink on dark backgrounds", () => {
+            expect(readableInk("#1e293b")).toBe("#fafaf9")
+        })
+    })
+
+    describe("relativeLuminance", () => {
+        it("orders black < grey < white", () => {
+            expect(relativeLuminance("#000000")).toBeLessThan(relativeLuminance("#808080"))
+            expect(relativeLuminance("#808080")).toBeLessThan(relativeLuminance("#ffffff"))
+        })
+    })
+
+    describe("shiftHue", () => {
+        it("rotating 360 degrees is a no-op within tolerance", () => {
+            const hex = "#e11d48"
+            const shifted = shiftHue(hex, 360)
+            const a = hexToRgb(hex)
+            const b = hexToRgb(shifted)
+            expect(Math.abs(a.r - b.r)).toBeLessThanOrEqual(2)
+            expect(Math.abs(a.g - b.g)).toBeLessThanOrEqual(2)
+            expect(Math.abs(a.b - b.b)).toBeLessThanOrEqual(2)
+        })
+        it("changes hue for a partial rotation", () => {
+            expect(shiftHue("#e11d48", 120)).not.toBe("#e11d48")
+        })
+    })
+
+    describe("hueDistance", () => {
+        it("is symmetric and wraps around 360", () => {
+            expect(hueDistance(10, 350)).toBe(20)
+            expect(hueDistance(350, 10)).toBe(20)
+            expect(hueDistance(0, 180)).toBe(180)
+            expect(hueDistance(90, 90)).toBe(0)
+        })
+    })
+})

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,117 @@
+// Small, dependency-free color utilities used to derive per-identity sticky
+// note palettes and readable ink colors from a user's accent color.
+
+export interface HSL {
+    h: number // 0..360
+    s: number // 0..100
+    l: number // 0..100
+}
+
+export interface RGB {
+    r: number // 0..255
+    g: number
+    b: number
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value))
+}
+
+/** Normalize a hex string to "#rrggbb" (lowercase). Returns null if invalid. */
+export function normalizeHex(hex: string): string | null {
+    if (typeof hex !== "string") return null
+    let h = hex.trim().replace(/^#/, "")
+    if (h.length === 3) {
+        h = h
+            .split("")
+            .map(c => c + c)
+            .join("")
+    }
+    if (!/^[0-9a-fA-F]{6}$/.test(h)) return null
+    return "#" + h.toLowerCase()
+}
+
+export function hexToRgb(hex: string): RGB {
+    const normalized = normalizeHex(hex) ?? "#000000"
+    const int = parseInt(normalized.slice(1), 16)
+    return {
+        r: (int >> 16) & 0xff,
+        g: (int >> 8) & 0xff,
+        b: int & 0xff,
+    }
+}
+
+export function rgbToHex({ r, g, b }: RGB): string {
+    const toHex = (v: number) => clamp(Math.round(v), 0, 255).toString(16).padStart(2, "0")
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+export function hexToHsl(hex: string): HSL {
+    const { r, g, b } = hexToRgb(hex)
+    const rr = r / 255
+    const gg = g / 255
+    const bb = b / 255
+    const max = Math.max(rr, gg, bb)
+    const min = Math.min(rr, gg, bb)
+    const delta = max - min
+    let h = 0
+    if (delta !== 0) {
+        if (max === rr) h = ((gg - bb) / delta) % 6
+        else if (max === gg) h = (bb - rr) / delta + 2
+        else h = (rr - gg) / delta + 4
+        h *= 60
+        if (h < 0) h += 360
+    }
+    const l = (max + min) / 2
+    const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1))
+    return { h, s: s * 100, l: l * 100 }
+}
+
+export function hslToHex({ h, s, l }: HSL): string {
+    const hue = ((h % 360) + 360) % 360
+    const sat = clamp(s, 0, 100) / 100
+    const lum = clamp(l, 0, 100) / 100
+    const c = (1 - Math.abs(2 * lum - 1)) * sat
+    const x = c * (1 - Math.abs(((hue / 60) % 2) - 1))
+    const m = lum - c / 2
+    let r = 0
+    let g = 0
+    let b = 0
+    if (hue < 60) [r, g, b] = [c, x, 0]
+    else if (hue < 120) [r, g, b] = [x, c, 0]
+    else if (hue < 180) [r, g, b] = [0, c, x]
+    else if (hue < 240) [r, g, b] = [0, x, c]
+    else if (hue < 300) [r, g, b] = [x, 0, c]
+    else [r, g, b] = [c, 0, x]
+    return rgbToHex({ r: (r + m) * 255, g: (g + m) * 255, b: (b + m) * 255 })
+}
+
+/** WCAG relative luminance (0..1). */
+export function relativeLuminance(hex: string): number {
+    const { r, g, b } = hexToRgb(hex)
+    const channel = (v: number) => {
+        const s = v / 255
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+}
+
+/** Pick a legible ink color (near-black or near-white) for a given background. */
+export function readableInk(bgHex: string, darkInk = "#1c1917", lightInk = "#fafaf9"): string {
+    return relativeLuminance(bgHex) > 0.45 ? darkInk : lightInk
+}
+
+export function shiftHue(hex: string, degrees: number): string {
+    const hsl = hexToHsl(hex)
+    return hslToHex({ ...hsl, h: hsl.h + degrees })
+}
+
+export function withHsl(hex: string, patch: Partial<HSL>): string {
+    return hslToHex({ ...hexToHsl(hex), ...patch })
+}
+
+/** Smallest absolute distance between two hues, in degrees (0..180). */
+export function hueDistance(a: number, b: number): number {
+    const d = Math.abs(((a - b) % 360 + 360) % 360)
+    return d > 180 ? 360 - d : d
+}

--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -1,22 +1,112 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { activeUser, displayAbbreviations, userPreferences } from '$lib/stores/app'
   import { hapticLight } from '$lib/haptics'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { UserId } from '$lib/types'
 
+  const STORAGE_KEY = 'identity-pill-pos'
+  const DRAG_THRESHOLD = 6
+  const EDGE_MARGIN = 8
+
   let isExpanded = $state(false)
   let pillEl = $state<HTMLDivElement | null>(null)
+  // Persisted top-left position (px). Null = default bottom-right anchor.
+  let pos = $state<{ x: number; y: number } | null>(null)
+  let dragging = $state(false)
 
-  // stopPropagation keeps the window click handler from seeing this tap and
-  // immediately collapsing the pill (the toggle re-renders and detaches the
-  // trigger, so an outside-click check would otherwise wrongly fire).
+  // Non-reactive drag internals
+  let pointerId: number | null = null
+  let grabDX = 0
+  let grabDY = 0
+  let startX = 0
+  let startY = 0
+  let justDragged = false
+
+  onMount(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) pos = JSON.parse(stored)
+    } catch (e) {
+      console.warn('Failed to load pill position:', e)
+    }
+    // Clamp after layout so a resized viewport can't strand the pill offscreen.
+    requestAnimationFrame(clampIntoView)
+    const onResize = () => clampIntoView()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  })
+
+  function clampIntoView(): void {
+    if (!pos || !pillEl) return
+    const rect = pillEl.getBoundingClientRect()
+    const maxX = Math.max(EDGE_MARGIN, window.innerWidth - rect.width - EDGE_MARGIN)
+    const maxY = Math.max(EDGE_MARGIN, window.innerHeight - rect.height - EDGE_MARGIN)
+    pos = {
+      x: Math.min(Math.max(EDGE_MARGIN, pos.x), maxX),
+      y: Math.min(Math.max(EDGE_MARGIN, pos.y), maxY),
+    }
+  }
+
+  function onPointerDown(e: PointerEvent): void {
+    if (e.button && e.button !== 0) return
+    if (!pillEl) return
+    const rect = pillEl.getBoundingClientRect()
+    grabDX = e.clientX - rect.left
+    grabDY = e.clientY - rect.top
+    startX = e.clientX
+    startY = e.clientY
+    dragging = false
+    pointerId = e.pointerId
+    pillEl.setPointerCapture(e.pointerId)
+  }
+
+  function onPointerMove(e: PointerEvent): void {
+    if (pointerId === null || !pillEl) return
+    const dx = e.clientX - startX
+    const dy = e.clientY - startY
+    if (!dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
+      dragging = true
+      hapticLight()
+    }
+    if (dragging) {
+      e.preventDefault()
+      const rect = pillEl.getBoundingClientRect()
+      const maxX = window.innerWidth - rect.width - EDGE_MARGIN
+      const maxY = window.innerHeight - rect.height - EDGE_MARGIN
+      pos = {
+        x: Math.min(Math.max(EDGE_MARGIN, e.clientX - grabDX), maxX),
+        y: Math.min(Math.max(EDGE_MARGIN, e.clientY - grabDY), maxY),
+      }
+    }
+  }
+
+  function onPointerUp(e: PointerEvent): void {
+    if (pointerId === null || !pillEl) return
+    try { pillEl.releasePointerCapture(e.pointerId) } catch { /* already released */ }
+    pointerId = null
+    if (dragging) {
+      // Suppress the click that follows a drag so it doesn't toggle/select.
+      justDragged = true
+      setTimeout(() => { justDragged = false }, 0)
+      try {
+        if (pos) localStorage.setItem(STORAGE_KEY, JSON.stringify(pos))
+      } catch (err) {
+        console.warn('Failed to save pill position:', err)
+      }
+    }
+    dragging = false
+  }
+
   function toggle(e: MouseEvent): void {
     e.stopPropagation()
+    if (justDragged) return
     isExpanded = !isExpanded
   }
 
   function selectUser(e: MouseEvent, userId: UserId): void {
     e.stopPropagation()
+    if (justDragged) return
     hapticLight()
     activeUser.set(userId)
     isExpanded = false
@@ -35,11 +125,21 @@
   }
 
   const users: UserId[] = ['Z', 'T']
+
+  let posStyle = $derived(pos ? `left:${pos.x}px; top:${pos.y}px; right:auto; bottom:auto;` : '')
 </script>
 
 <svelte:window onkeydown={handleKeydown} onclick={handleOutsideClick} />
 
-<div bind:this={pillEl} class="fixed bottom-20 right-4 z-30">
+<div
+  bind:this={pillEl}
+  class="pill-root fixed z-30 touch-none select-none {pos ? '' : 'bottom-20 right-4'} {dragging ? 'is-dragging' : ''}"
+  style={posStyle}
+  onpointerdown={onPointerDown}
+  onpointermove={onPointerMove}
+  onpointerup={onPointerUp}
+  onpointercancel={onPointerUp}
+>
   {#if isExpanded}
     <!-- Expanded picker -->
     <div
@@ -63,10 +163,10 @@
       {/each}
     </div>
   {:else}
-    <!-- Collapsed trigger -->
+    <!-- Collapsed trigger (tap to switch, hold and drag to move) -->
     <button
       type="button"
-      aria-label="Switch user"
+      aria-label="Switch user — hold and drag to move"
       class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-lg transition-transform hover:scale-105 touch-manipulation"
       style:background-color={$userPreferences[$activeUser]?.accentColor ?? DEFAULT_ACCENT}
       onclick={toggle}
@@ -75,3 +175,9 @@
     </button>
   {/if}
 </div>
+
+<style>
+  .pill-root :global(button) { cursor: grab; }
+  .pill-root.is-dragging { cursor: grabbing; }
+  .pill-root.is-dragging :global(button) { cursor: grabbing; }
+</style>

--- a/src/lib/components/ui/PageHeader.svelte
+++ b/src/lib/components/ui/PageHeader.svelte
@@ -19,18 +19,22 @@
 </script>
 
 <header class="mb-6">
-  <div class="flex items-center justify-center gap-3 mb-1">
+  <div class="flex items-center gap-3">
     {#if icon}
       {@const Icon = icon}
-      <Icon size={iconSize} class="text-accent" />
+      <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-accent/10 text-accent shrink-0">
+        <Icon size={iconSize} />
+      </div>
     {/if}
-    <h1 class="text-2xl font-bold">{title}</h1>
+    <div class="min-w-0">
+      <h1 class="text-2xl font-extrabold leading-tight tracking-tight truncate">{title}</h1>
+      {#if subtitle}
+        <p class="text-slate-500 dark:text-slate-400 text-sm truncate">
+          {subtitle}
+        </p>
+      {/if}
+    </div>
   </div>
-  {#if subtitle}
-    <p class="text-center text-slate-500 dark:text-slate-400 text-sm">
-      {subtitle}
-    </p>
-  {/if}
   {#if children}
     <div class="mt-4">
       {@render children()}

--- a/src/lib/notePalette.test.ts
+++ b/src/lib/notePalette.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest"
+import {
+    getNotePalette,
+    resolveToneShift,
+    resolveNoteTone,
+    NOTE_TONE_KEYS,
+    COLLISION_SHIFT_DEG,
+} from "./notePalette"
+import type { UserPreferences, UserPreferencesMap } from "./types"
+
+function prefs(zAccent: string, tAccent: string): UserPreferencesMap {
+    const base: UserPreferences = {
+        theme: "dark",
+        accentColor: zAccent,
+        name: "Z",
+        unitSystem: "metric",
+        locationMode: "off",
+        searchRadius: 5000,
+    }
+    return {
+        Z: { ...base, accentColor: zAccent, name: "Z" },
+        T: { ...base, accentColor: tAccent, name: "T" },
+    }
+}
+
+const isHex = (s: string) => /^#[0-9a-f]{6}$/.test(s)
+
+describe("getNotePalette", () => {
+    it("produces one tone per slot with valid colors", () => {
+        const palette = getNotePalette("#e11d48")
+        expect(palette).toHaveLength(NOTE_TONE_KEYS.length)
+        palette.forEach((tone, i) => {
+            expect(tone.key).toBe(NOTE_TONE_KEYS[i])
+            expect(isHex(tone.bgLight)).toBe(true)
+            expect(isHex(tone.bgDark)).toBe(true)
+            expect(isHex(tone.tack)).toBe(true)
+            expect(isHex(tone.inkLight)).toBe(true)
+            expect(isHex(tone.inkDark)).toBe(true)
+        })
+    })
+
+    it("light backgrounds are lighter than dark backgrounds", () => {
+        const palette = getNotePalette("#7c3aed")
+        // A crude check: the light paper tone should have a higher green+red sum
+        // than the deep tone for the same slot.
+        const light = parseInt(palette[0].bgLight.slice(1), 16)
+        const dark = parseInt(palette[0].bgDark.slice(1), 16)
+        expect(light).toBeGreaterThan(dark)
+    })
+
+    it("falls back gracefully for empty accent", () => {
+        expect(getNotePalette("")).toHaveLength(6)
+    })
+})
+
+describe("resolveToneShift", () => {
+    it("does not shift when accents are far apart", () => {
+        const shift = resolveToneShift(prefs("#e11d48", "#0d9488"), true)
+        expect(shift.Z).toBe(0)
+        expect(shift.T).toBe(0)
+    })
+
+    it("shifts T when accents collide and auto-shift is on", () => {
+        const shift = resolveToneShift(prefs("#e11d48", "#e11d48"), true)
+        expect(shift.Z).toBe(0)
+        expect(shift.T).toBe(COLLISION_SHIFT_DEG)
+    })
+
+    it("never shifts when auto-shift is off", () => {
+        const shift = resolveToneShift(prefs("#e11d48", "#e11d48"), false)
+        expect(shift.T).toBe(0)
+    })
+})
+
+describe("resolveNoteTone", () => {
+    const p = prefs("#e11d48", "#7c3aed")
+    const shift = resolveToneShift(p, true)
+
+    it("maps a legacy named color onto a tonal slot", () => {
+        const tone = resolveNoteTone("Z", "yellow", p, shift)
+        expect(tone.key).toBe("t0")
+    })
+
+    it("uses the author's accent, not the viewer's", () => {
+        const zTone = resolveNoteTone("Z", "t2", p, shift)
+        const tTone = resolveNoteTone("T", "t2", p, shift)
+        // Same slot, different authors → different resolved colors.
+        expect(zTone.bgLight).not.toBe(tTone.bgLight)
+    })
+
+    it("defaults unknown colors to the first slot", () => {
+        const tone = resolveNoteTone("Z", undefined, p, shift)
+        expect(tone.key).toBe("t0")
+    })
+})

--- a/src/lib/notePalette.ts
+++ b/src/lib/notePalette.ts
@@ -1,0 +1,109 @@
+// Derives per-identity sticky-note palettes from each user's accent color so
+// that note authorship is legible at a glance: every note a user pins carries
+// a tone from their own accent family (rose vs. violet, say). When both users
+// pick near-identical accents, one family can be automatically hue-shifted so
+// the two remain distinguishable.
+
+import { hexToHsl, hslToHex, hueDistance, readableInk } from "./color"
+import type { NoteColor, UserId, UserPreferencesMap } from "./types"
+import { DEFAULT_ACCENT } from "./accents"
+
+export interface NoteTone {
+    /** Stored slot key (t0..t5). */
+    key: string
+    bgLight: string
+    bgDark: string
+    inkLight: string
+    inkDark: string
+    tack: string
+}
+
+// Six tonal slots. A note stores which slot it uses; the actual color is
+// resolved from the author's accent at render time.
+export const NOTE_TONE_KEYS = ["t0", "t1", "t2", "t3", "t4", "t5"] as const
+
+// Legacy notes stored named colors; map them onto slots so old notes keep the
+// same relative position within the new per-identity palette.
+const LEGACY_COLOR_INDEX: Record<string, number> = {
+    yellow: 0,
+    pink: 1,
+    blue: 2,
+    green: 3,
+    purple: 4,
+    orange: 5,
+    t0: 0,
+    t1: 1,
+    t2: 2,
+    t3: 3,
+    t4: 4,
+    t5: 5,
+}
+
+const HUE_OFFSETS = [-16, -8, 0, 10, 20, 30]
+const LIGHT_L = [90, 88, 91, 89, 87, 90]
+const DARK_L = [33, 31, 35, 32, 30, 34]
+
+// If two accents fall within this many degrees of hue, treat them as colliding.
+export const COLLISION_HUE_THRESHOLD = 34
+// How far to rotate the shifted identity's palette on collision.
+export const COLLISION_SHIFT_DEG = 42
+
+function toneIndex(color: NoteColor | string | undefined): number {
+    if (!color) return 0
+    return LEGACY_COLOR_INDEX[color] ?? 0
+}
+
+/** Build the six-tone paper palette for a given accent color. */
+export function getNotePalette(accentHex: string, shiftDeg = 0): NoteTone[] {
+    const base = hexToHsl(accentHex || DEFAULT_ACCENT)
+    const h = base.h + shiftDeg
+    const paperSat = Math.min(78, Math.max(42, base.s * 0.82))
+    const deepSat = Math.min(52, Math.max(26, base.s * 0.5))
+    const tackSat = Math.min(88, Math.max(48, base.s))
+
+    return NOTE_TONE_KEYS.map((key, i) => {
+        const hue = h + HUE_OFFSETS[i]
+        const bgLight = hslToHex({ h: hue, s: paperSat, l: LIGHT_L[i] })
+        const bgDark = hslToHex({ h: hue, s: deepSat, l: DARK_L[i] })
+        return {
+            key,
+            bgLight,
+            bgDark,
+            inkLight: readableInk(bgLight),
+            inkDark: readableInk(bgDark),
+            tack: hslToHex({ h: hue, s: tackSat, l: 50 }),
+        }
+    })
+}
+
+/**
+ * Decide how much (if any) to hue-shift each identity's palette. The first
+ * identity (Z) always keeps its true accent; T is rotated only when the two
+ * accents collide and auto tone-shift is enabled. Returns per-user shift in
+ * degrees.
+ */
+export function resolveToneShift(
+    prefs: UserPreferencesMap,
+    autoShift: boolean
+): Record<UserId, number> {
+    const zAccent = prefs.Z?.accentColor ?? DEFAULT_ACCENT
+    const tAccent = prefs.T?.accentColor ?? DEFAULT_ACCENT
+    let tShift = 0
+    if (autoShift) {
+        const collide = hueDistance(hexToHsl(zAccent).h, hexToHsl(tAccent).h) < COLLISION_HUE_THRESHOLD
+        if (collide) tShift = COLLISION_SHIFT_DEG
+    }
+    return { Z: 0, T: tShift }
+}
+
+/** Resolve the concrete tone for a single note, based on its author. */
+export function resolveNoteTone(
+    author: UserId,
+    color: NoteColor | string | undefined,
+    prefs: UserPreferencesMap,
+    shiftByUser: Record<UserId, number>
+): NoteTone {
+    const accent = prefs[author]?.accentColor ?? DEFAULT_ACCENT
+    const palette = getNotePalette(accent, shiftByUser[author] ?? 0)
+    return palette[toneIndex(color)]
+}

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -5,11 +5,13 @@
   import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte'
   import { addDocument, deleteDocument, subscribeToCollection, updateDocument } from '$lib/firebase'
   import { hapticLight, hapticMedium, hapticSuccess } from '$lib/haptics'
-  import { activeUser, displayNames } from '$lib/stores/app'
+  import { activeUser, currentPreferences, displayNames, userPreferences } from '$lib/stores/app'
   import { consumeQueryParam } from '$lib/stores/nav'
+  import { getNotePalette, resolveNoteTone, resolveToneShift, NOTE_TONE_KEYS, type NoteTone } from '$lib/notePalette'
+  import { DEFAULT_ACCENT } from '$lib/accents'
   import type { Note, NoteColor, UserId } from '$lib/types'
   import { Timestamp, type Timestamp as TimestampType } from 'firebase/firestore'
-  import { Archive, ArchiveRestore, Check, Image as ImageIcon, Pencil, Pin, StickyNote, Trash2, X } from 'lucide-svelte'
+  import { Archive, ArchiveRestore, Check, Image as ImageIcon, Pencil, Pin, Search, SlidersHorizontal, ArrowUpDown, StickyNote, Trash2, X } from 'lucide-svelte'
   import { onMount } from 'svelte'
   import { toast } from 'svelte-sonner'
 
@@ -20,11 +22,19 @@
 
   // Compose form state
   let composing = $state(false)
-  let newNote = $state({ title: '', content: '', color: 'yellow' as NoteColor })
+  let newNote = $state({ title: '', content: '', color: 't0' as NoteColor })
 
   // View: 'corkboard' | 'archive'
   type ViewKey = 'corkboard' | 'archive'
   let activeView = $state<ViewKey>('corkboard')
+
+  // Filter / sort state
+  let showFilters = $state(false)
+  let searchText = $state('')
+  let authorFilter = $state<'all' | UserId>('all')
+  let unreadOnly = $state(false)
+  type SortMode = 'newest' | 'oldest' | 'author'
+  let sortMode = $state<SortMode>('newest')
 
   // Cached timestamp for relative time calculations - updates every 60 seconds
   let now = $state(Date.now())
@@ -32,12 +42,40 @@
   // Get the other user's ID
   let otherUserId = $derived<UserId>($activeUser === 'Z' ? 'T' : 'Z')
 
-  const NOTE_COLORS: NoteColor[] = ['yellow', 'pink', 'blue', 'green', 'purple', 'orange']
+  // ===== Per-identity note palettes =====
+  // Each note is coloured from its author's accent so authorship reads at a
+  // glance; when both accents collide, one family is auto hue-shifted.
+  let toneShift = $derived(
+    resolveToneShift($userPreferences, $currentPreferences?.noteAutoToneShift ?? true)
+  )
+  let isDark = $derived(($currentPreferences?.theme ?? 'dark') === 'dark')
+  let myAccent = $derived($userPreferences[$activeUser]?.accentColor ?? DEFAULT_ACCENT)
+  let myPalette = $derived(getNotePalette(myAccent, toneShift[$activeUser] ?? 0))
+  let composeTone = $derived(
+    myPalette[Math.max(0, (NOTE_TONE_KEYS as readonly string[]).indexOf(newNote.color))]
+  )
+
+  function toneOf(note: Note): NoteTone {
+    return resolveNoteTone(note.createdBy, note.color, $userPreferences, toneShift)
+  }
+
+  function swatchBg(tone: NoteTone): string {
+    return isDark ? tone.bgDark : tone.bgLight
+  }
+
+  function noteVars(tone: NoteTone): string {
+    const bg = isDark ? tone.bgDark : tone.bgLight
+    const ink = isDark ? tone.inkDark : tone.inkLight
+    return `--note-bg:${bg};--note-ink:${ink};--note-tack:${tone.tack};`
+  }
+
+  function signatureFor(userId: UserId): string {
+    return ($userPreferences[userId]?.noteSignature ?? '').trim()
+  }
 
   // Deterministic rotation based on note id - slight tilt for realism
   function getNoteRotation(noteId: string | undefined): number {
     if (!noteId) return 0
-    // Hash the id to a stable rotation in range [-3, 3] degrees
     let hash = 0
     for (let i = 0; i < noteId.length; i++) {
       hash = (hash * 31 + noteId.charCodeAt(i)) & 0xffffffff
@@ -80,7 +118,7 @@
         },
         $activeUser
       )
-      newNote = { title: '', content: '', color: 'yellow' }
+      newNote = { title: '', content: '', color: 't0' }
       composing = false
       hapticSuccess()
       toast.success('Note pinned to board')
@@ -200,92 +238,179 @@
     selectedNote = null
   }
 
-  // Board notes: unarchived, pinned first then chronological
+  function resetFilters(): void {
+    searchText = ''
+    authorFilter = 'all'
+    unreadOnly = false
+    sortMode = 'newest'
+  }
+
+  let activeFilterCount = $derived(
+    (authorFilter !== 'all' ? 1 : 0) + (unreadOnly ? 1 : 0) + (searchText.trim() ? 1 : 0) + (sortMode !== 'newest' ? 1 : 0)
+  )
+
+  // Board notes: filtered + sorted, pinned first
   let boardNotes = $derived.by(() => {
-    const active = notes.filter(n => !n.archived)
-    return [...active].sort((a, b) => {
+    const q = searchText.trim().toLowerCase()
+    let list = notes.filter(n => !n.archived)
+    if (authorFilter !== 'all') list = list.filter(n => n.createdBy === authorFilter)
+    if (unreadOnly) list = list.filter(n => !n.read && n.createdBy !== $activeUser)
+    if (q) list = list.filter(n =>
+      (n.title ?? '').toLowerCase().includes(q) || (n.content ?? '').toLowerCase().includes(q)
+    )
+    return [...list].sort((a, b) => {
       if (a.pinned && !b.pinned) return -1
       if (!a.pinned && b.pinned) return 1
-      // Newest first
+      if (sortMode === 'author' && a.createdBy !== b.createdBy) {
+        return a.createdBy < b.createdBy ? -1 : 1
+      }
       const ta = a.createdAt?.toMillis?.() ?? 0
       const tb = b.createdAt?.toMillis?.() ?? 0
-      return tb - ta
+      return sortMode === 'oldest' ? ta - tb : tb - ta
     })
   })
 
+  let totalBoardCount = $derived(notes.filter(n => !n.archived).length)
   let archivedNotes = $derived(notes.filter(n => n.archived))
 
   // Unread count from other user
   let unreadCount = $derived(
     notes.filter(n => n.createdBy === otherUserId && !n.read && !n.archived).length
   )
+
+  const authorChips: Array<{ value: 'all' | UserId; label: string }> = [
+    { value: 'all', label: 'Everyone' },
+    { value: 'Z', label: 'Z' },
+    { value: 'T', label: 'T' },
+  ]
 </script>
 
-<!-- Cork board page -->
+<!-- Full-bleed cork backdrop (fixed behind the page content) -->
+<div class="cork-backdrop" aria-hidden="true"></div>
+
 <div class="corkboard-page">
-  <!-- Header bar -->
-  <div class="corkboard-header">
-    <div class="flex items-center gap-3">
+  <!-- Wooden control rail — the board's "tack & pen bin" -->
+  <div class="cork-rail">
+    <div class="flex items-center gap-2.5 min-w-0">
       <div class="corkboard-pin-icon">
-        <Pin size={18} />
+        <Pin size={16} />
       </div>
-      <div>
-        <h1 class="text-lg font-bold text-slate-800 dark:text-slate-100 leading-tight">Our Board</h1>
-        <p class="text-xs text-slate-500 dark:text-slate-400">{boardNotes.length} note{boardNotes.length === 1 ? '' : 's'} pinned</p>
+      <div class="min-w-0">
+        <h1 class="cork-title">Our Board</h1>
+        <p class="cork-subtitle">
+          {#if activeView === 'corkboard'}
+            {boardNotes.length}{boardNotes.length !== totalBoardCount ? `/${totalBoardCount}` : ''} note{totalBoardCount === 1 ? '' : 's'}
+          {:else}
+            {archivedNotes.length} archived
+          {/if}
+        </p>
       </div>
     </div>
 
-    <div class="flex items-center gap-2">
-      {#if unreadCount > 0}
+    <div class="flex items-center gap-1.5">
+      {#if unreadCount > 0 && activeView === 'corkboard'}
         <span class="unread-bubble">{unreadCount} new</span>
       {/if}
 
-      <!-- View toggle -->
-      <button
-        type="button"
-        class="btn-ghost text-sm px-3 py-2 {activeView === 'archive' ? 'text-accent' : ''}"
-        onclick={() => { activeView = activeView === 'corkboard' ? 'archive' : 'corkboard'; hapticLight(); }}
-      >
-        {#if activeView === 'archive'}
-          <StickyNote size={16} />
-          <span>Board</span>
-        {:else}
-          <Archive size={16} />
-          <span>Archive {archivedNotes.length > 0 ? `(${archivedNotes.length})` : ''}</span>
-        {/if}
-      </button>
-
-      <!-- Add note button -->
       {#if activeView === 'corkboard'}
         <button
           type="button"
-          class="btn-primary text-sm"
+          class="rail-btn {showFilters || activeFilterCount > 0 ? 'is-active' : ''}"
+          onclick={() => { showFilters = !showFilters; hapticLight(); }}
+          aria-label="Filter and sort"
+          aria-pressed={showFilters}
+        >
+          <SlidersHorizontal size={16} />
+          {#if activeFilterCount > 0}<span class="rail-badge">{activeFilterCount}</span>{/if}
+        </button>
+      {/if}
+
+      <button
+        type="button"
+        class="rail-btn {activeView === 'archive' ? 'is-active' : ''}"
+        onclick={() => { activeView = activeView === 'corkboard' ? 'archive' : 'corkboard'; hapticLight(); }}
+        aria-label={activeView === 'archive' ? 'Back to board' : 'Open archive'}
+      >
+        {#if activeView === 'archive'}
+          <StickyNote size={16} />
+        {:else}
+          <Archive size={16} />
+          {#if archivedNotes.length > 0}<span class="rail-badge">{archivedNotes.length}</span>{/if}
+        {/if}
+      </button>
+
+      {#if activeView === 'corkboard'}
+        <button
+          type="button"
+          class="rail-pen"
           onclick={() => { composing = !composing; hapticLight(); }}
           aria-label="Write a note"
         >
-          <Pencil size={16} />
+          <Pencil size={15} />
           <span class="hidden sm:inline">Write</span>
         </button>
       {/if}
     </div>
   </div>
 
-  <!-- Cork texture board area -->
-  {#if activeView === 'corkboard'}
-    <div class="cork-surface">
+  <!-- Filter / sort tray -->
+  {#if activeView === 'corkboard' && showFilters}
+    <div class="filter-tray">
+      <div class="relative flex-1 min-w-[10rem]">
+        <Search size={15} class="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+        <input
+          type="search"
+          placeholder="Search notes…"
+          class="tray-input pl-9"
+          bind:value={searchText}
+        />
+      </div>
 
+      <div class="tray-chips" role="group" aria-label="Filter by author">
+        {#each authorChips as chip}
+          <button
+            type="button"
+            class="tray-chip {authorFilter === chip.value ? 'is-on' : ''}"
+            onclick={() => { authorFilter = chip.value; hapticLight(); }}
+          >{chip.label}</button>
+        {/each}
+      </div>
+
+      <button
+        type="button"
+        class="tray-chip {unreadOnly ? 'is-on' : ''}"
+        onclick={() => { unreadOnly = !unreadOnly; hapticLight(); }}
+      >Unread</button>
+
+      <label class="tray-sort">
+        <ArrowUpDown size={14} class="text-slate-400" />
+        <select bind:value={sortMode} aria-label="Sort notes">
+          <option value="newest">Newest</option>
+          <option value="oldest">Oldest</option>
+          <option value="author">By author</option>
+        </select>
+      </label>
+
+      {#if activeFilterCount > 0}
+        <button type="button" class="tray-clear" onclick={resetFilters}>Clear</button>
+      {/if}
+    </div>
+  {/if}
+
+  {#if activeView === 'corkboard'}
+    <div class="notes-board">
       <!-- Compose sticky inline -->
       {#if composing}
-        <div class="compose-sticky note-{newNote.color}">
+        <div class="compose-sticky" style={noteVars(composeTone)}>
           <div class="sticky-top-tape"></div>
           <div class="p-4 pt-5 space-y-2">
             <div class="flex items-center justify-between mb-1">
-              <span class="text-xs font-semibold uppercase tracking-wider" style="color: rgba(0,0,0,0.55)">New note</span>
+              <span class="compose-eyebrow">New note · {$displayNames[$activeUser]}</span>
               <button
                 type="button"
-                class="transition-colors"
-                style="color: rgba(0,0,0,0.5)"
-                onclick={() => { composing = false; newNote = { title: '', content: '', color: 'yellow' }; }}
+                class="compose-x"
+                onclick={() => { composing = false; newNote = { title: '', content: '', color: 't0' }; }}
+                aria-label="Discard"
               >
                 <X size={16} />
               </button>
@@ -297,33 +422,30 @@
               bind:value={newNote.title}
             />
             <textarea
-              placeholder="Write something..."
+              placeholder="Write something for {$displayNames[otherUserId]}…"
               rows="4"
               class="sticky-input resize-none text-sm leading-relaxed"
               bind:value={newNote.content}
             ></textarea>
 
-            <!-- Color picker -->
+            <!-- Tone picker (author's palette) -->
             <div class="flex items-center gap-2 pt-1">
-              <span class="text-xs" style="color: rgba(0,0,0,0.5)">Color:</span>
+              <span class="compose-eyebrow">Tone</span>
               <div class="flex gap-1.5">
-                {#each NOTE_COLORS as color}
+                {#each NOTE_TONE_KEYS as key, i}
                   <button
                     type="button"
-                    class="touch-sm color-swatch note-{color} {newNote.color === color ? 'ring-2 ring-slate-600 ring-offset-1' : ''}"
-                    onclick={() => newNote.color = color}
-                    aria-label="Color {color}"
+                    class="touch-sm color-swatch {newNote.color === key ? 'is-selected' : ''}"
+                    style="background:{swatchBg(myPalette[i])}"
+                    onclick={() => newNote.color = key}
+                    aria-label="Tone {i + 1}"
                   ></button>
                 {/each}
               </div>
             </div>
 
             <div class="flex justify-end pt-1">
-              <button
-                type="button"
-                class="pin-btn"
-                onclick={addNote}
-              >
+              <button type="button" class="pin-btn" onclick={addNote}>
                 <Pin size={14} />
                 Pin it
               </button>
@@ -332,13 +454,12 @@
         </div>
       {/if}
 
-      <!-- Notes masonry grid -->
       {#if boardNotes.length === 0 && !composing}
         <div class="cork-empty">
           <EmptyState
             icon={StickyNote}
-            title="The board is empty"
-            description="Pin your first note for {$displayNames[otherUserId]}"
+            title={activeFilterCount > 0 ? 'No notes match' : 'The board is empty'}
+            description={activeFilterCount > 0 ? 'Try clearing the filters.' : `Pin your first note for ${$displayNames[otherUserId]}`}
           />
         </div>
       {:else}
@@ -346,26 +467,24 @@
           {#each boardNotes as note (note.id)}
             {@const isUnread = !note.read && note.createdBy !== $activeUser}
             {@const rot = getNoteRotation(note.id)}
+            {@const sig = signatureFor(note.createdBy)}
             <div
-              class="sticky-note note-{note.color ?? 'yellow'} {note.pinned ? 'is-pinned' : ''} {isUnread ? 'is-unread' : ''}"
-              style="--rot: {rot}deg"
+              class="sticky-note {note.pinned ? 'is-pinned' : ''} {isUnread ? 'is-unread' : ''}"
+              style="{noteVars(toneOf(note))}--rot:{rot}deg"
               onclick={() => openNoteDetail(note)}
               role="button"
               tabindex="0"
               onkeydown={(e) => e.key === 'Enter' && openNoteDetail(note)}
             >
-              <!-- Thumbtack -->
               <div class="thumbtack {note.pinned ? 'thumbtack-pinned' : ''}">
                 <div class="thumbtack-head"></div>
                 <div class="thumbtack-stem"></div>
               </div>
 
-              <!-- Unread dot -->
               {#if isUnread}
                 <div class="unread-dot"></div>
               {/if}
 
-              <!-- Note content -->
               <div class="sticky-body">
                 {#if note.title}
                   <h3 class="sticky-title">{note.title}</h3>
@@ -374,22 +493,23 @@
                   <p class="sticky-content">{note.content}</p>
                 {/if}
                 {#if note.photos?.length}
-                  <div class="flex items-center gap-1 mt-2 text-xs opacity-60">
+                  <div class="sticky-photos">
                     <ImageIcon size={12} />
                     <span>{note.photos.length} photo{note.photos.length === 1 ? '' : 's'}</span>
                   </div>
                 {/if}
+                {#if sig}
+                  <p class="sticky-sign">{sig}</p>
+                {/if}
               </div>
 
-              <!-- Footer: author + time -->
               <div class="sticky-footer">
-                <span class="sticky-author {note.createdBy === $activeUser ? 'opacity-50' : ''}">
+                <span class="sticky-author">
                   {note.createdBy === $activeUser ? 'You' : getDisplayNameForUser(note.createdBy)}
                 </span>
                 <span class="sticky-time">{getRelativeTime(note.createdAt)}</span>
               </div>
 
-              <!-- Hover action tray -->
               <div class="sticky-actions" role="none" onclick={(e) => e.stopPropagation()}>
                 <button
                   type="button"
@@ -439,11 +559,6 @@
   {:else}
     <!-- Archive view -->
     <div class="archive-view">
-      <div class="flex items-center gap-2 mb-4 px-1">
-        <Archive size={16} class="text-slate-400" />
-        <span class="text-sm text-slate-500">{archivedNotes.length} archived note{archivedNotes.length === 1 ? '' : 's'}</span>
-      </div>
-
       {#if archivedNotes.length === 0}
         <EmptyState
           icon={Archive}
@@ -453,8 +568,9 @@
       {:else}
         <div class="flex flex-col gap-3">
           {#each archivedNotes as note (note.id)}
+            {@const tone = toneOf(note)}
             <div
-              class="card p-4 cursor-pointer hover:border-accent/50 transition-colors"
+              class="archive-card"
               onclick={() => openNoteDetail(note)}
               role="button"
               tabindex="0"
@@ -463,7 +579,7 @@
               <div class="flex items-start justify-between gap-3">
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2 mb-1">
-                    <div class="w-2 h-2 rounded-full note-dot-{note.color ?? 'yellow'}"></div>
+                    <div class="w-2.5 h-2.5 rounded-full shrink-0" style="background:{tone.tack}"></div>
                     {#if note.title}
                       <h3 class="font-medium truncate">{note.title}</h3>
                     {:else}
@@ -507,11 +623,12 @@
 <Modal open={!!selectedNote} onclose={closeNoteDetail} title={selectedNote?.title || 'Note'}>
   {#snippet header()}
     {#if selectedNote}
-      {@const noteColor = selectedNote.color ?? 'yellow'}
-      <div class="relative modal-note-header note-header-{noteColor} p-6 shrink-0">
+      {@const tone = toneOf(selectedNote)}
+      <div class="relative modal-note-header p-6 shrink-0" style={noteVars(tone)}>
         <button
           class="absolute top-2 right-2 w-11 h-11 rounded-full bg-black/10 flex items-center justify-center hover:bg-black/20 transition-colors touch-manipulation"
           onclick={closeNoteDetail}
+          aria-label="Close"
         >
           <X size={20} />
         </button>
@@ -547,6 +664,10 @@
     <div class="space-y-5">
       {#if selectedNote.content}
         <p class="whitespace-pre-wrap text-slate-700 dark:text-slate-300 leading-relaxed">{selectedNote.content}</p>
+      {/if}
+
+      {#if signatureFor(selectedNote.createdBy)}
+        <p class="detail-sign">{signatureFor(selectedNote.createdBy)}</p>
       {/if}
 
       <!-- Photos -->
@@ -595,6 +716,7 @@
           type="button"
           class="btn-danger text-sm"
           onclick={() => { selectedNote?.id && removeNote(selectedNote.id); closeNoteDetail(); }}
+          aria-label="Delete note"
         >
           <Trash2 size={16} />
         </button>
@@ -627,16 +749,17 @@
         bind:value={editingNote.content}
       ></textarea>
 
-      <!-- Color picker -->
+      <!-- Tone picker -->
       <div class="flex items-center gap-3">
-        <span class="text-sm text-slate-500">Color:</span>
+        <span class="text-sm text-slate-500">Tone:</span>
         <div class="flex gap-2">
-          {#each NOTE_COLORS as color}
+          {#each NOTE_TONE_KEYS as key, i}
             <button
               type="button"
-              class="touch-sm color-swatch-lg note-{color} {editingNote.color === color ? 'ring-2 ring-slate-600 ring-offset-2' : ''}"
-              onclick={() => { if (editingNote) editingNote.color = color }}
-              aria-label="Color {color}"
+              class="touch-sm color-swatch-lg {editingNote.color === key ? 'is-selected' : ''}"
+              style="background:{swatchBg(myPalette[i])}"
+              onclick={() => { if (editingNote) editingNote.color = key }}
+              aria-label="Tone {i + 1}"
             ></button>
           {/each}
         </div>
@@ -664,31 +787,71 @@
 />
 
 <style>
-  /* ===== CORKBOARD PAGE ===== */
-  .corkboard-page {
-    min-height: calc(100vh - 5rem);
-    display: flex;
-    flex-direction: column;
+  /* ===== CORK BACKDROP (full-bleed page background) ===== */
+  .cork-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background:
+      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.09'/%3E%3C/svg%3E"),
+      radial-gradient(120% 120% at 50% 0%, #d4b895 0%, #c8a882 55%, #b9986f 100%);
+    box-shadow: inset 0 8px 24px rgba(0,0,0,0.18);
   }
 
-  /* Header */
-  .corkboard-header {
+  :global(.dark) .cork-backdrop {
+    background:
+      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.13'/%3E%3C/svg%3E"),
+      radial-gradient(120% 120% at 50% 0%, #8a6a44 0%, #7a5c3a 55%, #654b30 100%);
+    box-shadow: inset 0 8px 30px rgba(0,0,0,0.4);
+  }
+
+  .corkboard-page {
+    position: relative;
+    z-index: 1;
+    min-height: calc(100vh - 6rem);
+  }
+
+  /* ===== WOODEN CONTROL RAIL ===== */
+  .cork-rail {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem 1rem 0.75rem;
-    background: transparent;
+    gap: 0.5rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 0.9rem;
+    background: linear-gradient(180deg, #9a7b4f 0%, #86683f 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,0.18),
+      inset 0 -2px 4px rgba(0,0,0,0.25),
+      0 3px 8px rgba(0,0,0,0.25);
+    margin-bottom: 0.85rem;
   }
 
   .corkboard-pin-icon {
-    width: 2.25rem;
-    height: 2.25rem;
+    width: 2rem;
+    height: 2rem;
     border-radius: 50%;
     background: var(--color-accent);
     color: white;
     display: flex;
     align-items: center;
     justify-content: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    flex-shrink: 0;
+  }
+
+  .cork-title {
+    font-size: 1rem;
+    font-weight: 800;
+    line-height: 1.1;
+    color: #fdf6e9;
+    text-shadow: 0 1px 1px rgba(0,0,0,0.35);
+  }
+
+  .cork-subtitle {
+    font-size: 0.7rem;
+    color: rgba(253,246,233,0.75);
   }
 
   .unread-bubble {
@@ -701,25 +864,126 @@
     letter-spacing: 0.02em;
   }
 
-  /* Cork surface */
-  .cork-surface {
-    flex: 1;
-    padding: 1rem;
-    background:
-      /* Subtle noise texture via SVG data-uri */
-      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.08'/%3E%3C/svg%3E"),
-      #c8a882;
-    border-radius: 1rem;
-    margin: 0 0.5rem 1rem;
-    min-height: 24rem;
-    box-shadow: inset 0 2px 8px rgba(0,0,0,0.18), 0 1px 0 rgba(255,255,255,0.3);
+  /* Rail buttons (brass tacks in the bin) */
+  .rail-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.2rem;
+    height: 2.2rem;
+    padding: 0 0.5rem;
+    border-radius: 0.6rem;
+    color: #fdf6e9;
+    background: rgba(255,255,255,0.1);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
+    transition: background 120ms;
+  }
+  .rail-btn:hover { background: rgba(255,255,255,0.2); }
+  .rail-btn.is-active { background: var(--color-accent); }
+
+  .rail-badge {
+    margin-left: 0.3rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    background: rgba(0,0,0,0.25);
+    padding: 0.05rem 0.35rem;
+    border-radius: 999px;
   }
 
-  :global(.dark) .cork-surface {
-    background:
-      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.12'/%3E%3C/svg%3E"),
-      #7a5c3a;
-    box-shadow: inset 0 2px 10px rgba(0,0,0,0.4), 0 1px 0 rgba(255,255,255,0.08);
+  .rail-pen {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    height: 2.2rem;
+    padding: 0 0.75rem;
+    border-radius: 0.6rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: white;
+    background: var(--color-accent);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.25);
+    transition: filter 120ms;
+  }
+  .rail-pen:hover { filter: brightness(1.08); }
+
+  /* ===== FILTER TRAY ===== */
+  .filter-tray {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.7rem;
+    margin-bottom: 0.85rem;
+    border-radius: 0.85rem;
+    background: rgba(255,255,255,0.82);
+    backdrop-filter: blur(4px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  }
+  :global(.dark) .filter-tray {
+    background: rgba(30,26,22,0.8);
+  }
+
+  .tray-input {
+    width: 100%;
+    height: 2.25rem;
+    padding: 0 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.85rem;
+    outline: none;
+  }
+  .tray-input:focus { border-color: var(--color-accent); }
+
+  .tray-chips { display: inline-flex; gap: 0.25rem; }
+
+  .tray-chip {
+    height: 2.25rem;
+    padding: 0 0.7rem;
+    border-radius: 0.6rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-text-muted, #57534e);
+    background: var(--color-surface-2);
+    transition: background 120ms, color 120ms;
+  }
+  .tray-chip.is-on {
+    background: var(--color-accent);
+    color: white;
+  }
+
+  .tray-sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    height: 2.25rem;
+    padding: 0 0.6rem;
+    border-radius: 0.6rem;
+    background: var(--color-surface-2);
+  }
+  .tray-sort select {
+    background: transparent;
+    border: none;
+    outline: none;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .tray-clear {
+    height: 2.25rem;
+    padding: 0 0.6rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  /* ===== BOARD ===== */
+  .notes-board {
+    padding: 0.25rem 0.15rem 1rem;
+    min-height: 20rem;
   }
 
   .cork-empty {
@@ -727,26 +991,19 @@
     align-items: center;
     justify-content: center;
     min-height: 20rem;
+    background: rgba(255,255,255,0.35);
+    border-radius: 1rem;
+  }
+  :global(.dark) .cork-empty {
+    background: rgba(0,0,0,0.2);
   }
 
-  /* Notes masonry */
   .notes-masonry {
     columns: 2;
     column-gap: 0.75rem;
-    /* On wider screens show 3 columns */
   }
-
-  @media (min-width: 640px) {
-    .notes-masonry {
-      columns: 3;
-    }
-  }
-
-  @media (min-width: 900px) {
-    .notes-masonry {
-      columns: 4;
-    }
-  }
+  @media (min-width: 640px) { .notes-masonry { columns: 3; } }
+  @media (min-width: 900px) { .notes-masonry { columns: 4; } }
 
   /* ===== STICKY NOTE ===== */
   .sticky-note {
@@ -756,6 +1013,8 @@
     border-radius: 2px;
     padding: 0.875rem 0.875rem 0.6rem;
     cursor: pointer;
+    background: var(--note-bg, #fef08a);
+    color: var(--note-ink, #1c1917);
     transform: rotate(var(--rot, 0deg));
     transition: transform 150ms ease, box-shadow 150ms ease;
     box-shadow: 2px 3px 10px rgba(0,0,0,0.18), 0 1px 2px rgba(0,0,0,0.1);
@@ -784,21 +1043,6 @@
     box-shadow: 0 0 0 2px white;
   }
 
-  /* Sticky note color variants */
-  .note-yellow { background: #fef08a; }
-  .note-pink   { background: #fbcfe8; }
-  .note-blue   { background: #bae6fd; }
-  .note-green  { background: #bbf7d0; }
-  .note-purple { background: #e9d5ff; }
-  .note-orange { background: #fed7aa; }
-
-  :global(.dark) .note-yellow { background: #ca8a04; }
-  :global(.dark) .note-pink   { background: #be185d; }
-  :global(.dark) .note-blue   { background: #0369a1; }
-  :global(.dark) .note-green  { background: #15803d; }
-  :global(.dark) .note-purple { background: #7e22ce; }
-  :global(.dark) .note-orange { background: #c2410c; }
-
   /* Thumbtack */
   .thumbtack {
     position: absolute;
@@ -810,7 +1054,6 @@
     align-items: center;
     z-index: 2;
   }
-
   .thumbtack-head {
     width: 14px;
     height: 14px;
@@ -818,11 +1061,9 @@
     background: radial-gradient(circle at 35% 35%, #e5e7eb, #6b7280);
     box-shadow: 0 1px 3px rgba(0,0,0,0.4);
   }
-
   .thumbtack-pinned .thumbtack-head {
-    background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.7), var(--color-accent));
+    background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.75), var(--note-tack, #6366f1));
   }
-
   .thumbtack-stem {
     width: 2px;
     height: 5px;
@@ -830,17 +1071,14 @@
     border-radius: 0 0 1px 1px;
   }
 
-  /* Sticky note body */
-  .sticky-body {
-    margin-top: 0.5rem;
-    min-height: 2.5rem;
-  }
+  .sticky-body { margin-top: 0.5rem; min-height: 2.5rem; }
 
   .sticky-title {
     font-weight: 700;
     font-size: 0.875rem;
     line-height: 1.3;
-    color: rgba(0,0,0,0.75);
+    color: var(--note-ink);
+    opacity: 0.92;
     margin-bottom: 0.3rem;
     word-break: break-word;
   }
@@ -848,15 +1086,35 @@
   .sticky-content {
     font-size: 0.8rem;
     line-height: 1.45;
-    color: rgba(0,0,0,0.65);
+    color: var(--note-ink);
+    opacity: 0.78;
     white-space: pre-wrap;
     word-break: break-word;
-    /* Clamp to 6 lines on card */
     display: -webkit-box;
     -webkit-line-clamp: 6;
     line-clamp: 6;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .sticky-photos {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+    font-size: 0.7rem;
+    color: var(--note-ink);
+    opacity: 0.6;
+  }
+
+  .sticky-sign {
+    margin-top: 0.5rem;
+    font-style: italic;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--note-tack);
+    opacity: 0.85;
+    word-break: break-word;
   }
 
   .sticky-footer {
@@ -865,20 +1123,22 @@
     align-items: center;
     margin-top: 0.6rem;
     padding-top: 0.4rem;
-    border-top: 1px solid rgba(0,0,0,0.08);
+    border-top: 1px solid rgba(120,110,90,0.22);
   }
 
   .sticky-author {
     font-size: 0.65rem;
-    font-weight: 600;
-    color: rgba(0,0,0,0.5);
+    font-weight: 700;
+    color: var(--note-ink);
+    opacity: 0.55;
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
 
   .sticky-time {
     font-size: 0.65rem;
-    color: rgba(0,0,0,0.4);
+    color: var(--note-ink);
+    opacity: 0.42;
   }
 
   /* Hover action tray */
@@ -889,44 +1149,38 @@
     transform: translateX(-50%);
     display: flex;
     gap: 0.25rem;
-    background: white;
+    background: var(--color-surface);
     border-radius: 999px;
     padding: 0.25rem 0.5rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     opacity: 0;
     pointer-events: none;
     transition: opacity 120ms;
     z-index: 20;
     white-space: nowrap;
   }
-
   .sticky-note:hover .sticky-actions,
   .sticky-note:focus-within .sticky-actions {
     opacity: 1;
     pointer-events: auto;
   }
-
   @media (hover: none) {
-    /* On touch, keep actions hidden - use detail modal for actions */
-    .sticky-actions {
-      display: none;
-    }
+    .sticky-actions { display: none; }
   }
 
   .sticky-action-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
+    width: 1.9rem;
+    height: 1.9rem;
     border-radius: 50%;
-    color: #64748b;
+    color: var(--color-text-muted, #64748b);
     transition: color 100ms, background 100ms;
   }
-
   .sticky-action-btn:hover {
-    color: #1e293b;
-    background: #f1f5f9;
+    color: var(--color-text, #1e293b);
+    background: var(--color-surface-2);
   }
 
   /* ===== COMPOSE STICKY ===== */
@@ -934,7 +1188,9 @@
     position: relative;
     margin-bottom: 1rem;
     border-radius: 2px;
-    box-shadow: 3px 4px 14px rgba(0,0,0,0.2);
+    background: var(--note-bg);
+    color: var(--note-ink);
+    box-shadow: 3px 4px 14px rgba(0,0,0,0.24);
     max-width: 24rem;
     margin-left: auto;
     margin-right: auto;
@@ -952,17 +1208,33 @@
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
   }
 
+  .compose-eyebrow {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--note-ink);
+    opacity: 0.55;
+  }
+
+  .compose-x {
+    color: var(--note-ink);
+    opacity: 0.5;
+    transition: opacity 120ms;
+  }
+  .compose-x:hover { opacity: 0.85; }
+
   .sticky-input {
     width: 100%;
     background: transparent;
     border: none;
     outline: none;
-    color: rgba(0,0,0,0.75);
+    color: var(--note-ink);
     font-family: inherit;
   }
-
   .sticky-input::placeholder {
-    color: rgba(0,0,0,0.35);
+    color: var(--note-ink);
+    opacity: 0.4;
   }
 
   .pin-btn {
@@ -970,68 +1242,75 @@
     align-items: center;
     gap: 0.35rem;
     font-size: 0.8rem;
-    font-weight: 600;
-    padding: 0.35rem 0.85rem;
+    font-weight: 700;
+    padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    background: rgba(0,0,0,0.12);
-    color: rgba(0,0,0,0.65);
-    transition: background 150ms;
+    background: var(--note-tack);
+    color: white;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+    transition: filter 150ms;
   }
+  .pin-btn:hover { filter: brightness(1.08); }
 
-  .pin-btn:hover {
-    background: rgba(0,0,0,0.2);
-  }
-
-  /* Color swatch (small, in compose form) */
   .color-swatch {
-    width: 1.1rem;
-    height: 1.1rem;
+    width: 1.2rem;
+    height: 1.2rem;
     border-radius: 50%;
-    border: 1.5px solid rgba(0,0,0,0.15);
+    border: 1.5px solid rgba(0,0,0,0.18);
     cursor: pointer;
     transition: transform 100ms;
   }
-
-  .color-swatch:hover {
-    transform: scale(1.2);
+  .color-swatch:hover { transform: scale(1.2); }
+  .color-swatch.is-selected {
+    outline: 2px solid var(--note-ink);
+    outline-offset: 1px;
   }
 
-  /* Color swatch (larger, in edit modal) */
   .color-swatch-lg {
-    width: 1.6rem;
-    height: 1.6rem;
+    width: 1.7rem;
+    height: 1.7rem;
     border-radius: 50%;
-    border: 1.5px solid rgba(0,0,0,0.12);
+    border: 1.5px solid rgba(0,0,0,0.14);
     cursor: pointer;
     transition: transform 100ms;
   }
-
-  .color-swatch-lg:hover {
-    transform: scale(1.15);
+  .color-swatch-lg:hover { transform: scale(1.15); }
+  .color-swatch-lg.is-selected {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
   }
 
-  /* Archive view color dot */
-  .note-dot-yellow { background: #ca8a04; }
-  .note-dot-pink   { background: #be185d; }
-  .note-dot-blue   { background: #0284c7; }
-  .note-dot-green  { background: #16a34a; }
-  .note-dot-purple { background: #7c3aed; }
-  .note-dot-orange { background: #ea580c; }
+  /* Modal note header */
+  .modal-note-header {
+    background: var(--note-bg);
+    color: var(--note-ink);
+  }
 
-  /* Modal note header color */
-  .modal-note-header { color: rgba(0,0,0,0.8); }
-  .note-header-yellow { background: #fef08a; }
-  .note-header-pink   { background: #fbcfe8; }
-  .note-header-blue   { background: #bae6fd; }
-  .note-header-green  { background: #bbf7d0; }
-  .note-header-purple { background: #e9d5ff; }
-  .note-header-orange { background: #fed7aa; }
+  .detail-sign {
+    font-style: italic;
+    font-weight: 600;
+    color: var(--color-accent);
+    opacity: 0.9;
+  }
 
   /* Archive view */
   .archive-view {
-    padding: 1rem;
+    padding: 0.25rem 0.15rem 1rem;
     max-width: 42rem;
     margin: 0 auto;
+  }
+
+  .archive-card {
+    padding: 1rem;
+    border-radius: 0.85rem;
+    background: rgba(255,255,255,0.9);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.12);
+    cursor: pointer;
+    transition: box-shadow 150ms;
+  }
+  .archive-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.18); }
+  :global(.dark) .archive-card {
+    background: rgba(30,26,22,0.85);
   }
 
   /* Unread dot */

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -5,7 +5,7 @@
   import { hapticLight } from '$lib/haptics'
   import { activeUser, currentPreferences, displayAbbreviations, immediateSavePreferences, userPreferences } from '$lib/stores/app'
   import type { GeoLocation, LocationMode, NavMode, FontPreset, Theme, VideoSyncPlatform } from '$lib/types'
-  import { Camera, Info, Loader2, LogOut, MapPin, Moon, Palette, RefreshCw, Settings, Sun, User, Video, X, Download, ExternalLink as ExternalLinkIcon, Layout, Type } from 'lucide-svelte'
+  import { Camera, Info, Loader2, LogOut, MapPin, Moon, Palette, RefreshCw, Settings, Sun, User, Video, X, Download, ExternalLink as ExternalLinkIcon, Layout, Type, Sparkles } from 'lucide-svelte'
   import { toast } from 'svelte-sonner'
   import { isYouTubeAPIConfigured, requestAccessToken } from '$lib/services/youtube-sync'
   import { ACCENT_PRESETS, DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from '$lib/accents'
@@ -31,6 +31,10 @@
   let localVideoSyncPlatform = $state<VideoSyncPlatform>('none')
   let localNavMode = $state<NavMode>('bottom-tabs')
   let localFontPreset = $state<FontPreset>('warm-rounded')
+  let localFontScale = $state(1)
+  let localReduceMotion = $state(false)
+  let localNoteSignature = $state('')
+  let localNoteAutoToneShift = $state(true)
 
   // App state
   let isReloading = $state(false)
@@ -90,6 +94,10 @@
       localVideoSyncPlatform = $currentPreferences.videoSyncPlatform || 'none'
       localNavMode = $currentPreferences.navMode ?? 'bottom-tabs'
       localFontPreset = $currentPreferences.fontPreset ?? 'warm-rounded'
+      localFontScale = $currentPreferences.fontScale ?? 1
+      localReduceMotion = $currentPreferences.reduceMotion ?? false
+      localNoteSignature = $currentPreferences.noteSignature ?? ''
+      localNoteAutoToneShift = $currentPreferences.noteAutoToneShift ?? true
       previousUser = $activeUser
     }
   })
@@ -184,6 +192,10 @@
         grayjayConfig: prefs[$activeUser]?.grayjayConfig,
         navMode: localNavMode,
         fontPreset: localFontPreset,
+        fontScale: localFontScale,
+        reduceMotion: localReduceMotion,
+        noteSignature: localNoteSignature.trim() || undefined,
+        noteAutoToneShift: localNoteAutoToneShift,
         lastUpdated: Date.now()
       }
     }))
@@ -258,6 +270,40 @@
   function handleFontPresetChange(preset: FontPreset): void {
     hapticLight()
     localFontPreset = preset
+    savePreferences()
+  }
+
+  const FONT_SCALE_MIN = 0.85
+  const FONT_SCALE_MAX = 1.4
+  function handleFontScaleChange(): void {
+    // Clamp to the supported range so layout stays sane.
+    localFontScale = Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, Number(localFontScale) || 1))
+    savePreferences()
+  }
+  function nudgeFontScale(delta: number): void {
+    hapticLight()
+    localFontScale = Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, Math.round((localFontScale + delta) * 100) / 100))
+    savePreferences()
+  }
+  function resetFontScale(): void {
+    hapticLight()
+    localFontScale = 1
+    savePreferences()
+  }
+
+  function handleReduceMotionToggle(): void {
+    hapticLight()
+    localReduceMotion = !localReduceMotion
+    savePreferences()
+  }
+
+  function handleToneShiftToggle(): void {
+    hapticLight()
+    localNoteAutoToneShift = !localNoteAutoToneShift
+    savePreferences()
+  }
+
+  function handleSignatureChange(): void {
     savePreferences()
   }
 
@@ -492,6 +538,21 @@
           class="input"
           placeholder="Your name"
         />
+      </div>
+
+      <!-- Sticky-note signature -->
+      <div>
+        <label for="settings-note-signature" class="block text-sm font-medium mb-2">Sticky-note signature</label>
+        <input
+          id="settings-note-signature"
+          type="text"
+          bind:value={localNoteSignature}
+          onblur={handleSignatureChange}
+          class="input"
+          maxlength="40"
+          placeholder="e.g. — love, {localName || $activeUser} 💌"
+        />
+        <p class="text-xs text-slate-400 mt-1">A little sign-off shown on notes you pin. Leave blank for none.</p>
       </div>
 
       <!-- Theme -->
@@ -820,6 +881,75 @@
           </button>
         </div>
       </div>
+
+      <!-- Text size -->
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-sm font-medium">Text size</span>
+          <span class="text-xs text-slate-400 tabular-nums">{Math.round(localFontScale * 100)}%</span>
+        </div>
+        <div class="flex items-center gap-3">
+          <button type="button" class="btn-icon touch-sm" aria-label="Smaller text" onclick={() => nudgeFontScale(-0.05)}>
+            <span class="text-xs font-bold">A</span>
+          </button>
+          <input
+            type="range"
+            min="0.85"
+            max="1.4"
+            step="0.05"
+            bind:value={localFontScale}
+            oninput={handleFontScaleChange}
+            class="flex-1 accent-[var(--color-accent)]"
+            aria-label="Text size"
+          />
+          <button type="button" class="btn-icon touch-sm" aria-label="Larger text" onclick={() => nudgeFontScale(0.05)}>
+            <span class="text-lg font-bold">A</span>
+          </button>
+        </div>
+        {#if Math.abs(localFontScale - 1) > 0.001}
+          <button type="button" class="text-xs text-accent mt-2" onclick={resetFontScale}>Reset to 100%</button>
+        {/if}
+      </div>
+    </section>
+
+    <!-- Accessibility & Notes -->
+    <section class="card p-4 space-y-4">
+      <h2 class="text-sm font-medium text-slate-500 dark:text-slate-400 flex items-center gap-2">
+        <Sparkles size={16} />
+        Accessibility &amp; Notes
+      </h2>
+
+      <!-- Reduce motion -->
+      <button
+        type="button"
+        class="w-full flex items-center justify-between gap-3 touch-manipulation"
+        onclick={handleReduceMotionToggle}
+        aria-pressed={localReduceMotion}
+      >
+        <span class="text-left">
+          <span class="block text-sm font-medium">Reduce motion</span>
+          <span class="block text-xs text-slate-400">Turn off animations and tap bounce</span>
+        </span>
+        <span class="relative shrink-0 w-11 h-6 rounded-full transition-colors {localReduceMotion ? 'bg-accent' : 'bg-slate-300 dark:bg-slate-600'}" aria-hidden="true">
+          <span class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform {localReduceMotion ? 'translate-x-5' : ''}"></span>
+        </span>
+      </button>
+
+      <!-- Note tone-shift on collision -->
+      <button
+        type="button"
+        class="w-full flex items-center justify-between gap-3 touch-manipulation"
+        onclick={handleToneShiftToggle}
+        aria-pressed={localNoteAutoToneShift}
+      >
+        <span class="text-left">
+          <span class="block text-sm font-medium">Distinct note colors</span>
+          <span class="block text-xs text-slate-400">Shift note hues apart when both accents match</span>
+        </span>
+        <span class="relative shrink-0 w-11 h-6 rounded-full transition-colors {localNoteAutoToneShift ? 'bg-accent' : 'bg-slate-300 dark:bg-slate-600'}" aria-hidden="true">
+          <span class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform {localNoteAutoToneShift ? 'translate-x-5' : ''}"></span>
+        </span>
+      </button>
     </section>
 
     <!-- App Settings -->

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -35,6 +35,7 @@
   let localReduceMotion = $state(false)
   let localNoteSignature = $state('')
   let localNoteAutoToneShift = $state(true)
+  let localShowIdentityPill = $state(true)
 
   // App state
   let isReloading = $state(false)
@@ -98,6 +99,7 @@
       localReduceMotion = $currentPreferences.reduceMotion ?? false
       localNoteSignature = $currentPreferences.noteSignature ?? ''
       localNoteAutoToneShift = $currentPreferences.noteAutoToneShift ?? true
+      localShowIdentityPill = $currentPreferences.showIdentityPill ?? true
       previousUser = $activeUser
     }
   })
@@ -196,6 +198,7 @@
         reduceMotion: localReduceMotion,
         noteSignature: localNoteSignature.trim() || undefined,
         noteAutoToneShift: localNoteAutoToneShift,
+        showIdentityPill: localShowIdentityPill,
         lastUpdated: Date.now()
       }
     }))
@@ -300,6 +303,12 @@
   function handleToneShiftToggle(): void {
     hapticLight()
     localNoteAutoToneShift = !localNoteAutoToneShift
+    savePreferences()
+  }
+
+  function handleIdentityPillToggle(): void {
+    hapticLight()
+    localShowIdentityPill = !localShowIdentityPill
     savePreferences()
   }
 
@@ -851,6 +860,22 @@
           </button>
         </div>
       </div>
+
+      <!-- Identity switcher visibility -->
+      <button
+        type="button"
+        class="w-full flex items-center justify-between gap-3 touch-manipulation"
+        onclick={handleIdentityPillToggle}
+        aria-pressed={localShowIdentityPill}
+      >
+        <span class="text-left">
+          <span class="block text-sm font-medium">Floating identity switcher</span>
+          <span class="block text-xs text-slate-400">Tap to switch, hold and drag to reposition</span>
+        </span>
+        <span class="relative shrink-0 w-11 h-6 rounded-full transition-colors {localShowIdentityPill ? 'bg-accent' : 'bg-slate-300 dark:bg-slate-600'}" aria-hidden="true">
+          <span class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform {localShowIdentityPill ? 'translate-x-5' : ''}"></span>
+        </span>
+      </button>
     </section>
 
     <!-- Typography Settings -->

--- a/src/lib/pages/home/RecentActivityFeed.svelte
+++ b/src/lib/pages/home/RecentActivityFeed.svelte
@@ -73,7 +73,7 @@
             </div>
 
             <div class="flex flex-col items-end gap-1 flex-shrink-0">
-              <span class="text-xs font-medium text-accent">{item.createdBy}</span>
+              <span class="text-xs font-medium text-accent">{item.actor}</span>
               <span class="text-xs text-slate-400">{relativeTime(item)}</span>
             </div>
           </button>

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -42,6 +42,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         fontScale: 1,
         reduceMotion: false,
         noteAutoToneShift: true,
+        showIdentityPill: true,
         lastUpdated: Date.now(),
     },
     T: {
@@ -55,6 +56,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         fontScale: 1,
         reduceMotion: false,
         noteAutoToneShift: true,
+        showIdentityPill: true,
         lastUpdated: Date.now(),
     },
 }
@@ -144,6 +146,7 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
         "reduceMotion",
         "noteSignature",
         "noteAutoToneShift",
+        "showIdentityPill",
     ]
 
     for (const userId of ["Z", "T"] as const) {

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -39,6 +39,9 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         locationMode: "off",
         searchRadius: 5000,
         videoSyncPlatform: "none",
+        fontScale: 1,
+        reduceMotion: false,
+        noteAutoToneShift: true,
         lastUpdated: Date.now(),
     },
     T: {
@@ -49,6 +52,9 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         locationMode: "off",
         searchRadius: 5000,
         videoSyncPlatform: "none",
+        fontScale: 1,
+        reduceMotion: false,
+        noteAutoToneShift: true,
         lastUpdated: Date.now(),
     },
 }
@@ -134,6 +140,10 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
         "youtubePlaylistId",
         "navMode",
         "fontPreset",
+        "fontScale",
+        "reduceMotion",
+        "noteSignature",
+        "noteAutoToneShift",
     ]
 
     for (const userId of ["Z", "T"] as const) {

--- a/src/lib/stores/home.ts
+++ b/src/lib/stores/home.ts
@@ -34,6 +34,7 @@ function rebuildActivity(): void {
         title: m.title,
         subtitle: m.status,
         createdBy: m.createdBy,
+        actor: m.updatedBy ?? m.createdBy,
         updatedAt: m.updatedAt,
         posterPath: m.posterPath,
         mediaType: m.type,
@@ -45,6 +46,7 @@ function rebuildActivity(): void {
         title: n.title || "(untitled)",
         subtitle: n.tags?.[0],
         createdBy: n.createdBy,
+        actor: n.updatedBy ?? n.createdBy,
         updatedAt: n.updatedAt,
     }))
 
@@ -54,6 +56,7 @@ function rebuildActivity(): void {
         title: p.name,
         subtitle: p.category,
         createdBy: p.createdBy,
+        actor: p.updatedBy ?? p.createdBy,
         updatedAt: p.updatedAt,
     }))
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export interface UserPreferences {
     reduceMotion?: boolean // Disable non-essential animations/transitions
     noteSignature?: string // Short handwritten-style sign-off shown on this identity's notes
     noteAutoToneShift?: boolean // Auto hue-shift note palette when both accents collide (default true)
+    showIdentityPill?: boolean // Show the floating identity switcher (default true)
 }
 
 export type UserPreferencesMap = Record<UserId, UserPreferences>
@@ -373,6 +374,7 @@ export interface HomeActivity {
     title: string
     subtitle?: string       // e.g. status label or category
     createdBy: UserId
+    actor: UserId           // Who performed the most recent activity (updatedBy ?? createdBy)
     updatedAt: Timestamp
     posterPath?: string | null // Media poster, if available
     mediaType?: MediaType      // Only set when type === "media"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,10 @@ export interface UserPreferences {
     lastUpdated?: number // Timestamp for conflict resolution
     navMode?: NavMode    // Default: "bottom-tabs" on mobile, "sidebar" on desktop
     fontPreset?: FontPreset // Default: "warm-rounded"
+    fontScale?: number   // Global text-scale multiplier (0.85..1.4), default 1
+    reduceMotion?: boolean // Disable non-essential animations/transitions
+    noteSignature?: string // Short handwritten-style sign-off shown on this identity's notes
+    noteAutoToneShift?: boolean // Auto hue-shift note palette when both accents collide (default true)
 }
 
 export type UserPreferencesMap = Record<UserId, UserPreferences>
@@ -74,7 +78,12 @@ export interface BaseDocument {
     updatedBy?: UserId
 }
 
-export type NoteColor = "yellow" | "pink" | "blue" | "green" | "purple" | "orange"
+// Tonal slot (t0..t5) resolved to a concrete color from the author's accent at
+// render time. Legacy named colors are still accepted for notes stored before
+// the per-identity palette migration.
+export type NoteTone = "t0" | "t1" | "t2" | "t3" | "t4" | "t5"
+export type LegacyNoteColor = "yellow" | "pink" | "blue" | "green" | "purple" | "orange"
+export type NoteColor = NoteTone | LegacyNoteColor
 
 export interface Note extends BaseDocument {
     type: "note"


### PR DESCRIPTION
A follow-up pass focused on making the app feel personal and cozy rather than generic, centered on the notes experience. Addresses most of the requested follow-up list; a couple of the broadest items are staged as explicit next steps (see below).

## 1. Per-identity sticky-note palettes — attribution at a glance
- **`src/lib/color.ts`** (new, unit-tested): hex↔HSL conversion, WCAG relative luminance + a readable-ink picker, hue rotation/distance helpers.
- **`src/lib/notePalette.ts`** (new, unit-tested): every note is coloured from its **author's** accent, so Z's notes read rose-family and T's violet-family at a glance. Six tonal slots per identity; legacy named colors (`yellow`…`orange`) map onto slots so existing notes keep their relative tone. Light/dark-aware via CSS custom properties.
- **Collision tone-shift**: when both users pick near-identical accents, one family is automatically hue-shifted so the two stay distinguishable — with a Settings toggle to turn it off.

## 2. Corkboard as the page (less "SaaS", more real board)
- The cork texture is now a **full-bleed fixed page background** instead of a boxed element. Controls live in a wooden **"tack & pen bin" rail** (title, filter, archive, and a pen "Write" button). Notes render as paper tinted by the author's accent.

## 3. Filtering & sorting for notes
- Collapsible tray: text search, author chips (Everyone / Z / T), unread-only, and sort (newest / oldest / by author), with an active-filter count badge and a Clear action.

## 4. Custom sticky-note signatures
- Per-identity sign-off (e.g. `— love, Z 💌`) set in Settings, rendered on that identity's notes and in the detail view. Decoupled text but associated with the Z/T identities.

## 5. Enhanced settings that provide real value
- **Text-size scaling** (0.85×–1.4×) driving a root `--font-scale` that *multiplies the viewer's own browser size* (so it stacks with OS accessibility settings). A− / slider / A+ with a reset.
- **Reduce-motion** toggle: neutralizes transitions/animations and the tap-scale app-wide via `[data-reduce-motion]`, while preserving loading spinners.
- Note **signature** and **auto tone-shift** toggles (above).

## Cozy throughline polish
- `PageHeader` restyled **left-aligned and mobile-first** with a soft accent icon chip — this lifts Library / Places / Profiles / Settings at once. `.card` softened (`rounded-2xl` + subtle shadow).

## Mobile-first
- New interactive elements respect the existing 44px coarse-pointer targets; note action trays are hidden on touch (detail view is the touch affordance); rail/tray controls size up to 44px on touch.

## Deliberately staged for a focused next PR
- **Bespoke cozy redesigns of the remaining pages** (Videos reads most like a generic dashboard; Library/Places/Profiles get the shared-header lift here but not full per-page character yet). Doing each justice is its own effort — this PR lays the shared foundation (palette system, header, cards, motion/scale tokens) they'll build on.

## Verification
- `bun run check` — 0 errors, 0 warnings
- `bun run build` — succeeds
- `bun test:run` — **274 passed** (21 new: color + note-palette math)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_