### PR TITLE
Cozy pages: warm system with subtle per-page object metaphors

### DIFF
--- a/src/lib/components/BottomTabBar.svelte
+++ b/src/lib/components/BottomTabBar.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { Home, Library, StickyNote, MapPin, MoreHorizontal } from 'lucide-svelte'
+  import { MoreHorizontal } from 'lucide-svelte'
   import { navMode } from '$lib/stores/nav'
+  import { currentPreferences } from '$lib/stores/app'
+  import { TAB_DEFS, resolveTabs, type TabDef } from '$lib/tabs'
   import BottomSheet from './ui/BottomSheet.svelte'
-  import { Search, Video, Heart, Settings } from 'lucide-svelte'
 
   interface Props {
     activeRoute: string
@@ -13,21 +14,15 @@
 
   let moreOpen = $state(false)
 
-  const tabs = [
-    { path: '/', label: 'Home', icon: Home },
-    { path: '/library/movies', label: 'Library', icon: Library, matchPrefix: '/library' },
-    { path: '/notes', label: 'Notes', icon: StickyNote },
-    { path: '/places', label: 'Places', icon: MapPin },
-  ]
+  // Primary tabs come from the user's configuration; everything else falls
+  // into the "More" sheet.
+  let primaryTabs = $derived(resolveTabs($currentPreferences?.bottomTabs))
+  let moreItems = $derived.by(() => {
+    const shown = new Set(primaryTabs.map(t => t.key))
+    return TAB_DEFS.filter(t => !shown.has(t.key))
+  })
 
-  const moreItems = [
-    { path: '/search', label: 'Search', icon: Search },
-    { path: '/videos', label: 'Videos', icon: Video },
-    { path: '/profiles', label: 'Profiles', icon: Heart },
-    { path: '/settings', label: 'Settings', icon: Settings },
-  ]
-
-  function isActive(tab: { path: string; matchPrefix?: string }): boolean {
+  function isActive(tab: TabDef): boolean {
     if (tab.matchPrefix) return activeRoute.startsWith(tab.matchPrefix)
     return activeRoute === tab.path
   }
@@ -44,7 +39,7 @@
     aria-label="Main navigation"
   >
     <div class="flex items-stretch h-14">
-      {#each tabs as tab (tab.path)}
+      {#each primaryTabs as tab (tab.key)}
         {@const active = isActive(tab)}
         <button
           type="button"
@@ -59,27 +54,29 @@
         </button>
       {/each}
 
-      <!-- More button -->
-      <button
-        type="button"
-        aria-label="More"
-        class="flex-1 flex flex-col items-center justify-center gap-0.5 transition-colors touch-manipulation text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-        onclick={() => { moreOpen = true }}
-      >
-        <MoreHorizontal size={22} />
-        <span class="text-[10px] font-medium">More</span>
-      </button>
+      {#if moreItems.length > 0}
+        <!-- More button -->
+        <button
+          type="button"
+          aria-label="More"
+          class="flex-1 flex flex-col items-center justify-center gap-0.5 transition-colors touch-manipulation text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+          onclick={() => { moreOpen = true }}
+        >
+          <MoreHorizontal size={22} />
+          <span class="text-[10px] font-medium">More</span>
+        </button>
+      {/if}
     </div>
   </nav>
 
   <BottomSheet open={moreOpen} onClose={() => { moreOpen = false }} title="More">
     {#snippet children()}
       <nav class="space-y-1 py-2">
-        {#each moreItems as item (item.path)}
+        {#each moreItems as item (item.key)}
           <button
             type="button"
             class="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-left transition-colors touch-manipulation
-              {activeRoute === item.path ? 'bg-accent/10 text-accent' : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'}"
+              {isActive(item) ? 'bg-accent/10 text-accent' : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'}"
             onclick={() => handleMoreItem(item.path)}
           >
             <item.icon size={20} />

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -20,7 +20,6 @@
   } from '$lib/filters'
   import { onMount } from 'svelte'
   import MediaDetailModal from '$lib/components/MediaDetailModal.svelte'
-  import PageHeader from '$lib/components/ui/PageHeader.svelte'
   import IconButton from '$lib/components/ui/IconButton.svelte'
   import EmptyState from '$lib/components/ui/EmptyState.svelte'
   import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte'
@@ -457,29 +456,32 @@
 />
 
 <div class="max-w-6xl mx-auto">
-  <!-- Header with type navigation -->
-  <PageHeader
-    title={typeInfo[type].plural}
-    icon={typeInfo[type].icon}
-    subtitle="{typeMedia.length} item{typeMedia.length === 1 ? '' : 's'}"
-  >
-    {#snippet children()}
-      <!-- Type pills -->
-      <div class="flex justify-center gap-2">
+  <!-- Marquee header with type navigation -->
+  <div class="marquee mb-5">
+    <div class="marquee-lights" aria-hidden="true"></div>
+    <div class="marquee-inner">
+      <div class="flex items-end justify-between gap-3 flex-wrap">
+        <div class="min-w-0">
+          <p class="marquee-eyebrow">Now showing</p>
+          <h1 class="marquee-title">{typeInfo[type].plural}</h1>
+        </div>
+        <span class="marquee-count">{typeMedia.length} item{typeMedia.length === 1 ? '' : 's'}</span>
+      </div>
+
+      <!-- Type tickets -->
+      <div class="flex gap-2 overflow-x-auto scrollbar-none mt-3">
         {#each libraryTypes as t (t)}
           <button
             type="button"
-            class="px-4 py-2.5 rounded-full text-sm font-medium transition-colors touch-manipulation {t === type
-              ? 'bg-accent text-white'
-              : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'}"
+            class="ticket {t === type ? 'is-on' : ''}"
             onclick={() => navigate(`/library/${t === 'tv' ? 'tv' : t + 's'}`)}
           >
             {typeInfo[t].plural}
           </button>
         {/each}
       </div>
-    {/snippet}
-  </PageHeader>
+    </div>
+  </div>
 
   <!-- Action bar -->
   <div class="flex items-center justify-between gap-2 mb-4">
@@ -821,4 +823,72 @@
       opacity: 1;
     }
   }
+
+  /* ===== Cinema marquee header ===== */
+  .marquee {
+    position: relative;
+    border-radius: 1.1rem;
+    padding-top: 0.5rem;
+    background:
+      radial-gradient(120% 140% at 50% -20%, color-mix(in srgb, var(--color-accent) 55%, #1a1420) 0%, #1a1420 60%, #120e16 100%);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 10px 26px rgba(0,0,0,0.28);
+    overflow: hidden;
+  }
+  .marquee-lights {
+    height: 0.5rem;
+    background-image: radial-gradient(circle, #ffe9a8 0 40%, transparent 45%);
+    background-size: 1.05rem 0.5rem;
+    background-position: center;
+    background-repeat: repeat-x;
+    filter: drop-shadow(0 0 3px rgba(255,214,120,0.8));
+    opacity: 0.9;
+  }
+  .marquee-inner { padding: 0.9rem 1.1rem 1rem; }
+  .marquee-eyebrow {
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #ffcf6a;
+    text-shadow: 0 0 8px rgba(255,180,80,0.5);
+    margin-bottom: 0.1rem;
+  }
+  .marquee-title {
+    font-size: 1.7rem;
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    color: #fdf6e9;
+  }
+  .marquee-count {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: rgba(253,246,233,0.7);
+    padding-bottom: 0.2rem;
+  }
+
+  /* Ticket-stub type tabs */
+  .ticket {
+    position: relative;
+    height: 2.25rem;
+    padding: 0 0.95rem;
+    border-radius: 0.5rem;
+    font-size: 0.82rem;
+    font-weight: 700;
+    white-space: nowrap;
+    color: #efe6d6;
+    background: rgba(255,255,255,0.08);
+    -webkit-mask:
+      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
+      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
+    -webkit-mask-size: 51% 100%;
+    -webkit-mask-repeat: no-repeat;
+    mask:
+      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
+      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
+    mask-size: 51% 100%;
+    mask-repeat: no-repeat;
+    transition: background 120ms, color 120ms;
+  }
+  .ticket.is-on { background: #ffcf6a; color: #2a1e10; }
 </style>

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -9,7 +9,6 @@
   import PlaceSuggestions from '$lib/components/PlaceSuggestions.svelte'
   import LocationPicker from '$lib/components/LocationPicker.svelte'
   import PlaceDetailModal from '$lib/components/PlaceDetailModal.svelte'
-  import PageHeader from '$lib/components/ui/PageHeader.svelte'
   import IconButton from '$lib/components/ui/IconButton.svelte'
   import EmptyState from '$lib/components/ui/EmptyState.svelte'
   import Tabs from '$lib/components/ui/Tabs.svelte'
@@ -309,11 +308,24 @@
 />
 
 <div class="max-w-4xl mx-auto">
-  <PageHeader
-    title="Places"
-    icon={MapPin}
-    subtitle="{places.length} place{places.length === 1 ? '' : 's'}"
-  />
+  <!-- Travel-journal header -->
+  <div class="journal mb-5">
+    <div class="journal-inner">
+      <div class="flex items-end justify-between gap-3 flex-wrap">
+        <div class="min-w-0">
+          <p class="journal-eyebrow">Our map</p>
+          <h1 class="journal-title">Places</h1>
+        </div>
+        <span class="journal-count">
+          {#if places.length > 0}
+            {places.filter(p => p.visited).length}/{places.length} visited
+          {:else}
+            0 places
+          {/if}
+        </span>
+      </div>
+    </div>
+  </div>
 
   <!-- Action Bar -->
   <div class="flex items-center justify-between gap-2 mb-4">
@@ -482,13 +494,15 @@
       {@const Icon = categoryIcons[place.category]}
       {@const rating = getPlaceDisplayRating(place)}
       <div
-        class="group card p-4 transition-all cursor-pointer hover:border-accent"
-        class:opacity-70={place.visited}
+        class="group card p-4 transition-all cursor-pointer hover:border-accent relative overflow-hidden"
         onclick={() => selectedPlace = place}
         role="button"
         tabindex="0"
         onkeydown={(e) => e.key === 'Enter' && (selectedPlace = place)}
       >
+        {#if place.visited}
+          <span class="visited-stamp" aria-hidden="true">Visited</span>
+        {/if}
         <div class="flex items-start gap-4">
           <!-- Icon -->
           <div class="shrink-0 w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center text-accent">
@@ -498,7 +512,7 @@
           <!-- Content -->
           <div class="flex-1 min-w-0">
             <div class="flex items-start justify-between gap-2">
-              <h3 class="font-medium" class:line-through={place.visited}>{place.name}</h3>
+              <h3 class="font-medium">{place.name}</h3>
               {#if rating}
                 <div class="shrink-0 flex items-center gap-0.5 text-amber-400">
                   <span>★</span>
@@ -576,5 +590,71 @@
     .group:active .opacity-0 {
       opacity: 1;
     }
+  }
+
+  /* ===== Travel-journal / passport header ===== */
+  .journal {
+    position: relative;
+    border-radius: 1.1rem;
+    background:
+      radial-gradient(120% 140% at 50% -20%, color-mix(in srgb, var(--color-accent) 30%, #4a3524) 0%, #3d2b1c 55%, #2c1e14 100%);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 10px 26px rgba(0,0,0,0.28);
+    overflow: hidden;
+  }
+  /* stitched dashed border, like a passport page */
+  .journal::before {
+    content: "";
+    position: absolute;
+    inset: 0.5rem;
+    border: 1.5px dashed rgba(255,236,200,0.35);
+    border-radius: 0.7rem;
+    pointer-events: none;
+  }
+  .journal-inner { position: relative; padding: 1.1rem 1.3rem; }
+  .journal-eyebrow {
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #e9c893;
+    text-shadow: 0 0 8px rgba(220,170,90,0.35);
+    margin-bottom: 0.1rem;
+  }
+  .journal-title {
+    font-size: 1.7rem;
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    color: #fbf1df;
+  }
+  .journal-count {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: rgba(251,241,223,0.72);
+    padding-bottom: 0.2rem;
+  }
+
+  /* ===== "Visited" rubber stamp on place cards ===== */
+  .visited-stamp {
+    position: absolute;
+    bottom: 0.45rem;
+    right: 0.6rem;
+    transform: rotate(-11deg);
+    padding: 0.12rem 0.5rem;
+    border: 2px solid rgba(5,150,105,0.55);
+    border-radius: 0.3rem;
+    color: rgba(5,150,105,0.7);
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    pointer-events: none;
+    opacity: 0.85;
+    mix-blend-mode: multiply;
+  }
+  :global(.dark) .visited-stamp {
+    border-color: rgba(52,211,153,0.5);
+    color: rgba(52,211,153,0.75);
+    mix-blend-mode: screen;
   }
 </style>

--- a/src/lib/pages/Profiles.svelte
+++ b/src/lib/pages/Profiles.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import EmptyState from '$lib/components/ui/EmptyState.svelte'
-  import PageHeader from '$lib/components/ui/PageHeader.svelte'
   import Tabs from '$lib/components/ui/Tabs.svelte'
   import Modal from '$lib/components/ui/Modal.svelte'
   import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte'
   import { addDocument, deleteDocument, subscribeToCollection, updateDocument } from '$lib/firebase'
   import { hapticLight, hapticSuccess } from '$lib/haptics'
-  import { activeUser, displayNames } from '$lib/stores/app'
+  import { activeUser, displayNames, userPreferences } from '$lib/stores/app'
+  import { DEFAULT_ACCENT } from '$lib/accents'
   import type { ProfileItem, ProfileCategory, UserId } from '$lib/types'
   import { Heart, Pencil, Plus, Star, Trash2, Gift, Coffee, Music, Film, BookOpen, Zap, Sparkles, Palette, Users, MapPin, Utensils } from 'lucide-svelte'
   import { onMount } from 'svelte'
@@ -190,39 +190,37 @@
   function getUserDisplayName(userId: UserId): string {
     return $displayNames[userId] || userId
   }
+
+  // Tint each keepsake by its author's accent, echoing the notes system.
+  function accentFor(userId: UserId): string {
+    return $userPreferences[userId]?.accentColor ?? DEFAULT_ACCENT
+  }
 </script>
 
 <div class="max-w-2xl mx-auto">
 
-<PageHeader
-  title="Partner Profiles"
-  subtitle="Keep track of things we like"
-  icon={Heart}
->
-  {#snippet children()}
-    <!-- View mode toggle -->
-    <div class="flex gap-2 justify-center">
-      <button
-        class="{viewMode === 'both' ? 'btn-primary' : 'btn-secondary'} touch-manipulation"
-        onclick={() => { viewMode = 'both'; hapticLight() }}
-      >
-        Both
-      </button>
-      <button
-        class="{viewMode === 'mine' ? 'btn-primary' : 'btn-secondary'} touch-manipulation"
-        onclick={() => { viewMode = 'mine'; hapticLight() }}
-      >
-        Mine
-      </button>
-      <button
-        class="{viewMode === 'theirs' ? 'btn-primary' : 'btn-secondary'} touch-manipulation"
-        onclick={() => { viewMode = 'theirs'; hapticLight() }}
-      >
-        Theirs
-      </button>
+<!-- Keepsake-box header -->
+<div class="keepbox mb-5">
+  <div class="keepbox-inner">
+    <div class="min-w-0 mb-3">
+      <p class="keepbox-eyebrow">Little things</p>
+      <h1 class="keepbox-title">Our Keepsakes</h1>
+      <p class="keepbox-sub">The things we love, kept</p>
     </div>
-  {/snippet}
-</PageHeader>
+    <!-- View mode toggle -->
+    <div class="flex gap-1.5">
+      {#each [{ k: 'both', l: 'Both' }, { k: 'mine', l: 'Mine' }, { k: 'theirs', l: 'Theirs' }] as m}
+        <button
+          type="button"
+          class="keepbox-chip {viewMode === m.k ? 'is-on' : ''}"
+          onclick={() => { viewMode = m.k as typeof viewMode; hapticLight() }}
+        >
+          {m.l}
+        </button>
+      {/each}
+    </div>
+  </div>
+</div>
 
 <!-- Category tabs + Add button -->
 <div class="flex items-center gap-2">
@@ -271,7 +269,7 @@
         </h3>
         <div class="grid gap-3 md:grid-cols-2">
           {#each userItems as item (item.id)}
-            <div class="card p-4">
+            <div class="keepsake" style="--keepsake-accent: {accentFor(item.createdBy)}">
               <div class="flex items-start justify-between mb-2">
                 <div class="flex items-center gap-2 flex-1">
                   <span class="text-2xl">{categoryInfo[item.category].emoji}</span>
@@ -314,8 +312,8 @@
               {#if item.notes}
                 <p class="text-sm text-slate-500 dark:text-slate-400 italic mt-2">{item.notes}</p>
               {/if}
-              <div class="mt-2 text-xs text-slate-400 dark:text-slate-500">
-                {categoryInfo[item.category].label}
+              <div class="mt-2">
+                <span class="keepsake-tag">{categoryInfo[item.category].label}</span>
               </div>
             </div>
           {/each}
@@ -327,7 +325,7 @@
   <!-- Regular list view -->
   <div class="grid gap-3 md:grid-cols-2">
     {#each filteredItems as item (item.id)}
-      <div class="card p-4">
+      <div class="keepsake" style="--keepsake-accent: {accentFor(item.createdBy)}">
         <div class="flex items-start justify-between mb-2">
           <div class="flex items-center gap-2 flex-1">
             <span class="text-2xl">{categoryInfo[item.category].emoji}</span>
@@ -370,8 +368,8 @@
         {#if item.notes}
           <p class="text-sm text-slate-500 dark:text-slate-400 italic mt-2">{item.notes}</p>
         {/if}
-        <div class="mt-2 text-xs text-slate-400 dark:text-slate-500">
-          {categoryInfo[item.category].label}
+        <div class="mt-2">
+          <span class="keepsake-tag">{categoryInfo[item.category].label}</span>
         </div>
       </div>
     {/each}
@@ -509,3 +507,80 @@
 />
 
 </div>
+
+<style>
+  /* ===== Keepsake-box header ===== */
+  .keepbox {
+    position: relative;
+    border-radius: 1.1rem;
+    background:
+      radial-gradient(120% 140% at 50% -20%, color-mix(in srgb, var(--color-accent) 34%, #3a2540) 0%, #33203a 55%, #241729 100%);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.07), 0 10px 26px rgba(0,0,0,0.28);
+    overflow: hidden;
+  }
+  .keepbox-inner { padding: 1.1rem 1.3rem; }
+  .keepbox-eyebrow {
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #f3c6e6;
+    text-shadow: 0 0 8px rgba(230,150,210,0.4);
+    margin-bottom: 0.1rem;
+  }
+  .keepbox-title {
+    font-size: 1.7rem;
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    color: #fbeef7;
+  }
+  .keepbox-sub {
+    font-size: 0.8rem;
+    color: rgba(251,238,247,0.68);
+    margin-top: 0.15rem;
+  }
+  .keepbox-chip {
+    height: 2.25rem;
+    padding: 0 0.9rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #f3e7ef;
+    background: rgba(255,255,255,0.1);
+    transition: background 120ms, color 120ms;
+  }
+  .keepbox-chip.is-on { background: #f3c6e6; color: #3a1f33; }
+
+  /* ===== Keepsake item cards ===== */
+  .keepsake {
+    position: relative;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--keepsake-accent, var(--color-accent));
+    border-radius: 0.85rem;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.06), 0 6px 14px rgba(0,0,0,0.05);
+    transition: transform 140ms ease, box-shadow 140ms ease;
+  }
+  .keepsake:hover {
+    transform: rotate(-0.4deg) translateY(-2px);
+    box-shadow: 0 3px 8px rgba(0,0,0,0.1), 0 12px 24px rgba(0,0,0,0.1);
+  }
+
+  .keepsake-tag {
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    color: var(--color-text-muted, #57534e);
+    background: var(--color-surface-2);
+    padding: 0.12rem 0.55rem;
+    border-radius: 999px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .keepsake:hover { transform: none; }
+  }
+</style>

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -9,6 +9,8 @@
   import { toast } from 'svelte-sonner'
   import { isYouTubeAPIConfigured, requestAccessToken } from '$lib/services/youtube-sync'
   import { ACCENT_PRESETS, DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from '$lib/accents'
+  import { TAB_DEFS, DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS, tabDef } from '$lib/tabs'
+  import { ArrowUp, ArrowDown, Minus, Plus as PlusIcon } from 'lucide-svelte'
 
   interface Props {
     navigate: (path: string) => void
@@ -36,6 +38,7 @@
   let localNoteSignature = $state('')
   let localNoteAutoToneShift = $state(true)
   let localShowIdentityPill = $state(true)
+  let localBottomTabs = $state<string[]>([])
 
   // App state
   let isReloading = $state(false)
@@ -100,6 +103,7 @@
       localNoteSignature = $currentPreferences.noteSignature ?? ''
       localNoteAutoToneShift = $currentPreferences.noteAutoToneShift ?? true
       localShowIdentityPill = $currentPreferences.showIdentityPill ?? true
+      localBottomTabs = [...($currentPreferences.bottomTabs ?? DEFAULT_BOTTOM_TABS)]
       previousUser = $activeUser
     }
   })
@@ -199,6 +203,7 @@
         noteSignature: localNoteSignature.trim() || undefined,
         noteAutoToneShift: localNoteAutoToneShift,
         showIdentityPill: localShowIdentityPill,
+        bottomTabs: [...localBottomTabs],
         lastUpdated: Date.now()
       }
     }))
@@ -309,6 +314,39 @@
   function handleIdentityPillToggle(): void {
     hapticLight()
     localShowIdentityPill = !localShowIdentityPill
+    savePreferences()
+  }
+
+  // --- Bottom tab bar configuration ---
+  let availableTabs = $derived(TAB_DEFS.filter(t => !localBottomTabs.includes(t.key)))
+
+  function addBottomTab(key: string): void {
+    if (localBottomTabs.length >= MAX_BOTTOM_TABS || localBottomTabs.includes(key)) return
+    hapticLight()
+    localBottomTabs = [...localBottomTabs, key]
+    savePreferences()
+  }
+
+  function removeBottomTab(key: string): void {
+    if (localBottomTabs.length <= 1) return // keep at least one tab
+    hapticLight()
+    localBottomTabs = localBottomTabs.filter(k => k !== key)
+    savePreferences()
+  }
+
+  function moveBottomTab(index: number, dir: -1 | 1): void {
+    const target = index + dir
+    if (target < 0 || target >= localBottomTabs.length) return
+    hapticLight()
+    const next = [...localBottomTabs]
+    ;[next[index], next[target]] = [next[target], next[index]]
+    localBottomTabs = next
+    savePreferences()
+  }
+
+  function resetBottomTabs(): void {
+    hapticLight()
+    localBottomTabs = [...DEFAULT_BOTTOM_TABS]
     savePreferences()
   }
 
@@ -876,6 +914,81 @@
           <span class="absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform {localShowIdentityPill ? 'translate-x-5' : ''}"></span>
         </span>
       </button>
+
+      <!-- Bottom tab bar configuration -->
+      {#if localNavMode === 'bottom-tabs'}
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm font-medium">Bottom bar tabs</span>
+            <button type="button" class="text-xs text-accent" onclick={resetBottomTabs}>Reset</button>
+          </div>
+          <p class="text-xs text-slate-400 mb-3">Choose up to {MAX_BOTTOM_TABS} tabs and drag their order with the arrows. The rest live under "More".</p>
+
+          <!-- On the bar (ordered) -->
+          <ul class="space-y-2 mb-3">
+            {#each localBottomTabs as key, i (key)}
+              {@const def = tabDef(key)}
+              {#if def}
+                {@const TabIcon = def.icon}
+                <li class="flex items-center gap-2 p-2 rounded-xl border border-[var(--color-border)] bg-surface-2">
+                  <TabIcon size={18} class="text-accent shrink-0" />
+                  <span class="flex-1 text-sm font-medium truncate">{def.label}</span>
+                  <button
+                    type="button"
+                    class="btn-icon-sm touch-sm disabled:opacity-30"
+                    disabled={i === 0}
+                    onclick={() => moveBottomTab(i, -1)}
+                    aria-label="Move {def.label} up"
+                  >
+                    <ArrowUp size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    class="btn-icon-sm touch-sm disabled:opacity-30"
+                    disabled={i === localBottomTabs.length - 1}
+                    onclick={() => moveBottomTab(i, 1)}
+                    aria-label="Move {def.label} down"
+                  >
+                    <ArrowDown size={16} />
+                  </button>
+                  <button
+                    type="button"
+                    class="btn-icon-sm touch-sm hover:text-red-500 disabled:opacity-30"
+                    disabled={localBottomTabs.length <= 1}
+                    onclick={() => removeBottomTab(key)}
+                    aria-label="Remove {def.label}"
+                  >
+                    <Minus size={16} />
+                  </button>
+                </li>
+              {/if}
+            {/each}
+          </ul>
+
+          <!-- Available to add -->
+          {#if availableTabs.length > 0}
+            <span class="block text-xs text-slate-400 mb-2">Available</span>
+            <div class="flex flex-wrap gap-2">
+              {#each availableTabs as def (def.key)}
+                {@const TabIcon = def.icon}
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1.5 pl-2.5 pr-3 py-1.5 rounded-full border border-[var(--color-border)] text-sm font-medium disabled:opacity-40 hover:border-accent transition-colors touch-manipulation"
+                  disabled={localBottomTabs.length >= MAX_BOTTOM_TABS}
+                  onclick={() => addBottomTab(def.key)}
+                >
+                  <TabIcon size={15} />
+                  <span>{def.label}</span>
+                  <PlusIcon size={14} class="text-accent" />
+                </button>
+              {/each}
+            </div>
+            {#if localBottomTabs.length >= MAX_BOTTOM_TABS}
+              <p class="text-xs text-slate-400 mt-2">Remove a tab to add another (max {MAX_BOTTOM_TABS}).</p>
+            {/if}
+          {/if}
+        </div>
+      {/if}
     </section>
 
     <!-- Typography Settings -->

--- a/src/lib/pages/Videos.svelte
+++ b/src/lib/pages/Videos.svelte
@@ -273,14 +273,15 @@
 
 </script>
 
-<div class="min-h-screen bg-slate-50 dark:bg-slate-900">
-  <!-- Header -->
-  <div class="bg-white dark:bg-slate-800 border-b border-[var(--color-border)] sticky top-0 z-10">
-    <div class="max-w-7xl mx-auto px-4 py-4">
-      <div class="flex items-center justify-between mb-4">
-        <div class="flex items-center gap-3">
-          <VideoIcon size={28} class="text-accent" />
-          <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Video Queue</h1>
+<div class="videos-page pb-6">
+  <!-- Marquee header -->
+  <div class="marquee">
+    <div class="marquee-lights" aria-hidden="true"></div>
+    <div class="marquee-inner">
+      <div class="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <div class="min-w-0">
+          <p class="marquee-eyebrow">Now showing</p>
+          <h1 class="marquee-title">Video Queue</h1>
         </div>
         <div class="flex items-center gap-2">
           <!-- Sync button -->
@@ -288,7 +289,7 @@
             <button
               onclick={handleSync}
               disabled={syncing || !isSyncAvailable($currentPreferences)}
-              class="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:opacity-90 transition-opacity touch-feedback disabled:opacity-50"
+              class="marquee-btn touch-feedback disabled:opacity-50"
               title={getSyncStatusMessage($currentPreferences)}
             >
               <RefreshCw size={18} class={syncing ? 'animate-spin' : ''} />
@@ -301,7 +302,7 @@
             <div class="relative" data-export-menu>
               <button
                 onclick={() => showExportMenu = !showExportMenu}
-                class="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:opacity-90 transition-opacity touch-feedback"
+                class="marquee-btn touch-feedback"
               >
                 <Download size={18} />
                 <span class="hidden sm:inline">Export</span>
@@ -337,9 +338,9 @@
           
           <button
             onclick={openAddModal}
-            class="flex items-center gap-2 px-4 py-2 bg-accent text-white rounded-lg hover:opacity-90 transition-opacity touch-feedback"
+            class="marquee-btn marquee-btn-accent touch-feedback"
           >
-            <Plus size={20} />
+            <Plus size={18} />
             <span>Add Video</span>
           </button>
         </div>
@@ -355,23 +356,23 @@
         </div>
       {/if}
 
-      <!-- Filter tabs -->
-      <div class="flex gap-2 overflow-x-auto">
+      <!-- Ticket-stub filter tabs -->
+      <div class="flex gap-2 overflow-x-auto scrollbar-none pt-1">
         <button
           onclick={() => { filterStatus = 'all'; hapticLight() }}
-          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'all' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
+          class="ticket {filterStatus === 'all' ? 'is-on' : ''}"
         >
           All ({videos.length})
         </button>
         <button
           onclick={() => { filterStatus = 'queued'; hapticLight() }}
-          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'queued' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
+          class="ticket {filterStatus === 'queued' ? 'is-on' : ''}"
         >
           Queued ({videos.filter(v => v.status === 'queued').length})
         </button>
         <button
           onclick={() => { filterStatus = 'watched'; hapticLight() }}
-          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'watched' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
+          class="ticket {filterStatus === 'watched' ? 'is-on' : ''}"
         >
           Watched ({videos.filter(v => v.status === 'watched').length})
         </button>
@@ -395,11 +396,12 @@
     {:else}
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {#each filteredVideos as video (video.id)}
-          <div class="bg-white dark:bg-slate-800 rounded-lg overflow-hidden shadow-sm border border-[var(--color-border)] hover:shadow-md transition-shadow">
+          <div class="film-card">
+            <div class="film-strip" aria-hidden="true"></div>
             <!-- Thumbnail -->
             <button
               onclick={() => openVideoDetail(video)}
-              class="relative w-full aspect-video bg-slate-100 dark:bg-slate-900 overflow-hidden group"
+              class="relative w-full aspect-video bg-black/90 overflow-hidden group block"
             >
               {#if video.thumbnailUrl}
                 <img
@@ -558,3 +560,138 @@
   onConfirm={() => pendingConfirm?.onConfirm()}
   onCancel={() => pendingConfirm = null}
 />
+
+<style>
+  /* ===== Cinema marquee header ===== */
+  .marquee {
+    position: relative;
+    border-radius: 1.1rem;
+    margin-bottom: 1.25rem;
+    padding-top: 0.5rem;
+    background:
+      radial-gradient(120% 140% at 50% -20%, color-mix(in srgb, var(--color-accent) 55%, #1a1420) 0%, #1a1420 60%, #120e16 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,0.08),
+      0 10px 26px rgba(0,0,0,0.28);
+    overflow: hidden;
+  }
+  /* Row of marquee bulbs along the top edge */
+  .marquee-lights {
+    height: 0.5rem;
+    background-image: radial-gradient(circle, #ffe9a8 0 40%, transparent 45%);
+    background-size: 1.05rem 0.5rem;
+    background-position: center;
+    background-repeat: repeat-x;
+    filter: drop-shadow(0 0 3px rgba(255,214,120,0.8));
+    opacity: 0.9;
+  }
+  .marquee-inner { padding: 0.9rem 1.1rem 1rem; }
+
+  .marquee-eyebrow {
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #ffcf6a;
+    text-shadow: 0 0 8px rgba(255,180,80,0.5);
+    margin-bottom: 0.1rem;
+  }
+  .marquee-title {
+    font-size: 1.6rem;
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    color: #fdf6e9;
+  }
+
+  .marquee-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    height: 2.5rem;
+    padding: 0 0.85rem;
+    border-radius: 0.65rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #f4ede0;
+    background: rgba(255,255,255,0.1);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
+    transition: background 120ms;
+    white-space: nowrap;
+  }
+  .marquee-btn:hover { background: rgba(255,255,255,0.18); }
+  .marquee-btn-accent {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.25);
+  }
+  .marquee-btn-accent:hover { filter: brightness(1.08); background: var(--color-accent); }
+
+  /* Ticket-stub filter tabs */
+  .ticket {
+    position: relative;
+    height: 2.25rem;
+    padding: 0 0.9rem;
+    border-radius: 0.5rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    white-space: nowrap;
+    color: #efe6d6;
+    background: rgba(255,255,255,0.08);
+    /* notched ticket edges */
+    -webkit-mask:
+      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
+      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
+    -webkit-mask-size: 51% 100%;
+    -webkit-mask-repeat: no-repeat;
+    mask:
+      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
+      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
+    mask-size: 51% 100%;
+    mask-repeat: no-repeat;
+    transition: background 120ms, color 120ms;
+  }
+  .ticket.is-on {
+    background: #ffcf6a;
+    color: #2a1e10;
+  }
+
+  /* ===== Film-strip video cards ===== */
+  .film-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 0.9rem;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.08), 0 6px 16px rgba(0,0,0,0.06);
+    transition: box-shadow 150ms, transform 150ms;
+  }
+  .film-card:hover {
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1), 0 12px 26px rgba(0,0,0,0.12);
+    transform: translateY(-2px);
+  }
+  /* Sprocket-hole strip above the thumbnail */
+  .film-strip {
+    height: 0.85rem;
+    background:
+      repeating-linear-gradient(90deg, transparent 0 0.35rem, #e9e2d4 0.35rem 0.75rem),
+      #1a1420;
+    background-blend-mode: normal;
+    position: relative;
+  }
+  .film-strip::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle, #1a1420 0 42%, transparent 46%);
+    background-size: 0.75rem 0.85rem;
+    background-position: 0.05rem center;
+    background-repeat: repeat-x;
+  }
+  :global(.dark) .film-strip {
+    background: repeating-linear-gradient(90deg, transparent 0 0.35rem, #3a332a 0.35rem 0.75rem), #0d0a11;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .film-card:hover { transform: none; }
+  }
+</style>

--- a/src/lib/pages/Videos.svelte
+++ b/src/lib/pages/Videos.svelte
@@ -273,15 +273,14 @@
 
 </script>
 
-<div class="videos-page pb-6">
-  <!-- Marquee header -->
-  <div class="marquee">
-    <div class="marquee-lights" aria-hidden="true"></div>
-    <div class="marquee-inner">
-      <div class="flex items-center justify-between gap-3 mb-4 flex-wrap">
-        <div class="min-w-0">
-          <p class="marquee-eyebrow">Now showing</p>
-          <h1 class="marquee-title">Video Queue</h1>
+<div class="min-h-screen bg-slate-50 dark:bg-slate-900">
+  <!-- Header -->
+  <div class="bg-white dark:bg-slate-800 border-b border-[var(--color-border)] sticky top-0 z-10">
+    <div class="max-w-7xl mx-auto px-4 py-4">
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <VideoIcon size={28} class="text-accent" />
+          <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Video Queue</h1>
         </div>
         <div class="flex items-center gap-2">
           <!-- Sync button -->
@@ -289,7 +288,7 @@
             <button
               onclick={handleSync}
               disabled={syncing || !isSyncAvailable($currentPreferences)}
-              class="marquee-btn touch-feedback disabled:opacity-50"
+              class="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:opacity-90 transition-opacity touch-feedback disabled:opacity-50"
               title={getSyncStatusMessage($currentPreferences)}
             >
               <RefreshCw size={18} class={syncing ? 'animate-spin' : ''} />
@@ -302,7 +301,7 @@
             <div class="relative" data-export-menu>
               <button
                 onclick={() => showExportMenu = !showExportMenu}
-                class="marquee-btn touch-feedback"
+                class="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:opacity-90 transition-opacity touch-feedback"
               >
                 <Download size={18} />
                 <span class="hidden sm:inline">Export</span>
@@ -338,9 +337,9 @@
           
           <button
             onclick={openAddModal}
-            class="marquee-btn marquee-btn-accent touch-feedback"
+            class="flex items-center gap-2 px-4 py-2 bg-accent text-white rounded-lg hover:opacity-90 transition-opacity touch-feedback"
           >
-            <Plus size={18} />
+            <Plus size={20} />
             <span>Add Video</span>
           </button>
         </div>
@@ -356,23 +355,23 @@
         </div>
       {/if}
 
-      <!-- Ticket-stub filter tabs -->
-      <div class="flex gap-2 overflow-x-auto scrollbar-none pt-1">
+      <!-- Filter tabs -->
+      <div class="flex gap-2 overflow-x-auto">
         <button
           onclick={() => { filterStatus = 'all'; hapticLight() }}
-          class="ticket {filterStatus === 'all' ? 'is-on' : ''}"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'all' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
         >
           All ({videos.length})
         </button>
         <button
           onclick={() => { filterStatus = 'queued'; hapticLight() }}
-          class="ticket {filterStatus === 'queued' ? 'is-on' : ''}"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'queued' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
         >
           Queued ({videos.filter(v => v.status === 'queued').length})
         </button>
         <button
           onclick={() => { filterStatus = 'watched'; hapticLight() }}
-          class="ticket {filterStatus === 'watched' ? 'is-on' : ''}"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap {filterStatus === 'watched' ? 'bg-accent text-white' : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'}"
         >
           Watched ({videos.filter(v => v.status === 'watched').length})
         </button>
@@ -396,12 +395,11 @@
     {:else}
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {#each filteredVideos as video (video.id)}
-          <div class="film-card">
-            <div class="film-strip" aria-hidden="true"></div>
+          <div class="bg-white dark:bg-slate-800 rounded-lg overflow-hidden shadow-sm border border-[var(--color-border)] hover:shadow-md transition-shadow">
             <!-- Thumbnail -->
             <button
               onclick={() => openVideoDetail(video)}
-              class="relative w-full aspect-video bg-black/90 overflow-hidden group block"
+              class="relative w-full aspect-video bg-slate-100 dark:bg-slate-900 overflow-hidden group"
             >
               {#if video.thumbnailUrl}
                 <img
@@ -560,138 +558,3 @@
   onConfirm={() => pendingConfirm?.onConfirm()}
   onCancel={() => pendingConfirm = null}
 />
-
-<style>
-  /* ===== Cinema marquee header ===== */
-  .marquee {
-    position: relative;
-    border-radius: 1.1rem;
-    margin-bottom: 1.25rem;
-    padding-top: 0.5rem;
-    background:
-      radial-gradient(120% 140% at 50% -20%, color-mix(in srgb, var(--color-accent) 55%, #1a1420) 0%, #1a1420 60%, #120e16 100%);
-    box-shadow:
-      inset 0 1px 0 rgba(255,255,255,0.08),
-      0 10px 26px rgba(0,0,0,0.28);
-    overflow: hidden;
-  }
-  /* Row of marquee bulbs along the top edge */
-  .marquee-lights {
-    height: 0.5rem;
-    background-image: radial-gradient(circle, #ffe9a8 0 40%, transparent 45%);
-    background-size: 1.05rem 0.5rem;
-    background-position: center;
-    background-repeat: repeat-x;
-    filter: drop-shadow(0 0 3px rgba(255,214,120,0.8));
-    opacity: 0.9;
-  }
-  .marquee-inner { padding: 0.9rem 1.1rem 1rem; }
-
-  .marquee-eyebrow {
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: #ffcf6a;
-    text-shadow: 0 0 8px rgba(255,180,80,0.5);
-    margin-bottom: 0.1rem;
-  }
-  .marquee-title {
-    font-size: 1.6rem;
-    font-weight: 800;
-    line-height: 1.05;
-    letter-spacing: -0.01em;
-    color: #fdf6e9;
-  }
-
-  .marquee-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    height: 2.5rem;
-    padding: 0 0.85rem;
-    border-radius: 0.65rem;
-    font-size: 0.85rem;
-    font-weight: 700;
-    color: #f4ede0;
-    background: rgba(255,255,255,0.1);
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
-    transition: background 120ms;
-    white-space: nowrap;
-  }
-  .marquee-btn:hover { background: rgba(255,255,255,0.18); }
-  .marquee-btn-accent {
-    background: var(--color-accent);
-    color: #fff;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.25);
-  }
-  .marquee-btn-accent:hover { filter: brightness(1.08); background: var(--color-accent); }
-
-  /* Ticket-stub filter tabs */
-  .ticket {
-    position: relative;
-    height: 2.25rem;
-    padding: 0 0.9rem;
-    border-radius: 0.5rem;
-    font-size: 0.8rem;
-    font-weight: 700;
-    white-space: nowrap;
-    color: #efe6d6;
-    background: rgba(255,255,255,0.08);
-    /* notched ticket edges */
-    -webkit-mask:
-      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
-      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
-    -webkit-mask-size: 51% 100%;
-    -webkit-mask-repeat: no-repeat;
-    mask:
-      radial-gradient(circle 5px at 0 50%, transparent 98%, #000) left,
-      radial-gradient(circle 5px at 100% 50%, transparent 98%, #000) right;
-    mask-size: 51% 100%;
-    mask-repeat: no-repeat;
-    transition: background 120ms, color 120ms;
-  }
-  .ticket.is-on {
-    background: #ffcf6a;
-    color: #2a1e10;
-  }
-
-  /* ===== Film-strip video cards ===== */
-  .film-card {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 0.9rem;
-    overflow: hidden;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.08), 0 6px 16px rgba(0,0,0,0.06);
-    transition: box-shadow 150ms, transform 150ms;
-  }
-  .film-card:hover {
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1), 0 12px 26px rgba(0,0,0,0.12);
-    transform: translateY(-2px);
-  }
-  /* Sprocket-hole strip above the thumbnail */
-  .film-strip {
-    height: 0.85rem;
-    background:
-      repeating-linear-gradient(90deg, transparent 0 0.35rem, #e9e2d4 0.35rem 0.75rem),
-      #1a1420;
-    background-blend-mode: normal;
-    position: relative;
-  }
-  .film-strip::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: radial-gradient(circle, #1a1420 0 42%, transparent 46%);
-    background-size: 0.75rem 0.85rem;
-    background-position: 0.05rem center;
-    background-repeat: repeat-x;
-  }
-  :global(.dark) .film-strip {
-    background: repeating-linear-gradient(90deg, transparent 0 0.35rem, #3a332a 0.35rem 0.75rem), #0d0a11;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .film-card:hover { transform: none; }
-  }
-</style>

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -7,6 +7,7 @@ import {
 } from "../firebase"
 import type { UserId, UserPreferences, UserPreferencesMap } from "../types"
 import { DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from "../accents"
+import { DEFAULT_BOTTOM_TABS } from "../tabsConfig"
 
 // Touch device detection store
 // Uses pointer: coarse media query which is more reliable than touch event detection
@@ -43,6 +44,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         reduceMotion: false,
         noteAutoToneShift: true,
         showIdentityPill: true,
+        bottomTabs: [...DEFAULT_BOTTOM_TABS],
         lastUpdated: Date.now(),
     },
     T: {
@@ -57,6 +59,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         reduceMotion: false,
         noteAutoToneShift: true,
         showIdentityPill: true,
+        bottomTabs: [...DEFAULT_BOTTOM_TABS],
         lastUpdated: Date.now(),
     },
 }
@@ -147,6 +150,7 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
         "noteSignature",
         "noteAutoToneShift",
         "showIdentityPill",
+        "bottomTabs",
     ]
 
     for (const userId of ["Z", "T"] as const) {
@@ -166,6 +170,12 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
                 if (!aLoc && !bLoc) continue
                 if (!aLoc || !bLoc) return false
                 if (aLoc.lat !== bLoc.lat || aLoc.lng !== bLoc.lng) return false
+            } else if (key === "bottomTabs") {
+                const aArr = aVal as string[] | undefined
+                const bArr = bVal as string[] | undefined
+                if (!aArr && !bArr) continue
+                if (!aArr || !bArr || aArr.length !== bArr.length) return false
+                if (aArr.some((v, i) => v !== bArr[i])) return false
             } else if (aVal !== bVal) {
                 return false
             }

--- a/src/lib/tabs.ts
+++ b/src/lib/tabs.ts
@@ -1,0 +1,49 @@
+// Canonical registry of navigable destinations that can appear in the bottom
+// tab bar. The bar is user-configurable: `bottomTabs` in preferences is an
+// ordered list of these keys shown as primary tabs; everything else falls into
+// the "More" sheet.
+
+import type { ComponentType } from "svelte"
+import { Home, Library, StickyNote, MapPin, Search, Video, Heart, Settings } from "lucide-svelte"
+import { DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS } from "./tabsConfig"
+
+export { DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS }
+
+export interface TabDef {
+    key: string
+    label: string
+    path: string
+    icon: ComponentType
+    matchPrefix?: string // active when the route starts with this (e.g. /library)
+}
+
+export const TAB_DEFS: TabDef[] = [
+    { key: "home", label: "Home", path: "/", icon: Home },
+    { key: "media", label: "Media", path: "/library/movies", icon: Library, matchPrefix: "/library" },
+    { key: "notes", label: "Notes", path: "/notes", icon: StickyNote },
+    { key: "places", label: "Places", path: "/places", icon: MapPin },
+    { key: "search", label: "Search", path: "/search", icon: Search },
+    { key: "videos", label: "Videos", path: "/videos", icon: Video },
+    { key: "profiles", label: "Profiles", path: "/profiles", icon: Heart },
+    { key: "settings", label: "Settings", path: "/settings", icon: Settings },
+]
+
+export function tabDef(key: string): TabDef | undefined {
+    return TAB_DEFS.find(t => t.key === key)
+}
+
+/** Resolve a stored key list into valid, de-duplicated tab defs. */
+export function resolveTabs(keys: string[] | undefined): TabDef[] {
+    const source = keys && keys.length > 0 ? keys : DEFAULT_BOTTOM_TABS
+    const seen = new Set<string>()
+    const out: TabDef[] = []
+    for (const key of source) {
+        if (seen.has(key)) continue
+        const def = tabDef(key)
+        if (def) {
+            out.push(def)
+            seen.add(key)
+        }
+    }
+    return out.slice(0, MAX_BOTTOM_TABS)
+}

--- a/src/lib/tabsConfig.ts
+++ b/src/lib/tabsConfig.ts
@@ -1,0 +1,8 @@
+// Pure tab configuration constants — no icon/component imports, so this stays
+// cheap to pull into stores (e.g. app.ts) without dragging in lucide-svelte.
+
+// Default primary tabs (in order). Media is on the bar by default.
+export const DEFAULT_BOTTOM_TABS = ["home", "media", "notes", "places"]
+
+// A sensible ceiling so the bar (plus the "More" button) stays tappable.
+export const MAX_BOTTOM_TABS = 5

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,7 @@ export interface UserPreferences {
     noteSignature?: string // Short handwritten-style sign-off shown on this identity's notes
     noteAutoToneShift?: boolean // Auto hue-shift note palette when both accents collide (default true)
     showIdentityPill?: boolean // Show the floating identity switcher (default true)
+    bottomTabs?: string[] // Ordered tab keys shown in the bottom bar (rest go under "More")
 }
 
 export type UserPreferencesMap = Record<UserId, UserPreferences>


### PR DESCRIPTION
One **warm system** with a **subtle physical-object metaphor** per page. All page headers now share the same rhythm (eyebrow + big title + count), each with its own object.

## Pages
### 🎬 Media (movies/TV/games) → cinema marquee
Marquee header (bulb lights, "Now showing", item count) + **ticket-stub type tabs**. The Videos page stays plain (its glow-up is functional — see #63).

### 📍 Places → pinned travel journal / passport
Leather-journal header with a **stitched dashed border** ("Our map", visited/total count). Visited places get a **rotated rubber-stamp** instead of being dimmed/struck-through — visiting is celebratory.

### 💗 Profiles → keepsakes
Warm **keepsake-box** header ("Little things / Our Keepsakes") with chip toggles. Preference items are **keepsake cards**, each tinted on its left edge by the **author's accent** (echoing the notes identity system), with a gentle tilt on hover and a category tag.

## 🎚️ Configurable bottom tab bar
Per-user `bottomTabs` preference drives the bar — **pick which tabs (up to 5) and their order**; the rest go under "More"; **Media is a default tab**. Configurator in **Settings → Navigation** (reorder / add / remove / reset). Pure-config split (`tabsConfig.ts`) keeps the icon barrel out of the store.

## Not in this PR — tracked separately
- YouTube/Videos functional overhaul (cross-account linking + real sync, Grayjay import) → #63.

## Verification
- `bun run check` — 0 errors, 0 warnings
- `bun run build` — succeeds
- `bun test:run` — 274 passing

The metaphor set is coherent and I think this is ready for a full review. Preview link in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)