### PR TITLE
Fix settings sync clobbering the other identity; add manual save

### DIFF
--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -73,10 +73,12 @@ import {
     deleteDocument,
     logOut,
     onAuthChange,
+    savePreferencesToFirestore,
     signInWithGoogle,
     subscribeToCollection,
     updateDocument,
 } from "./firebase"
+import type { UserPreferencesMap } from "./types"
 
 describe("Firebase utilities", () => {
     beforeEach(() => {
@@ -260,6 +262,36 @@ describe("Firebase utilities", () => {
             await deleteDocument("places", "place-789")
 
             expect(firestore.doc).toHaveBeenCalledWith(expect.anything(), "places", "place-789")
+        })
+    })
+
+    describe("savePreferencesToFirestore", () => {
+        const prefs = {
+            Z: { name: "Zed", accentColor: "#e11d48" },
+            T: { name: "Tee", accentColor: "#7c3aed" },
+        } as unknown as UserPreferencesMap
+
+        it("writes ONLY the active user's entry (merge) when a userId is given", async () => {
+            await savePreferencesToFirestore(prefs, "Z")
+
+            const call = vi.mocked(firestore.setDoc).mock.calls[0]
+            const data = call[1] as Record<string, unknown>
+            const options = call[2]
+
+            expect(data).toHaveProperty("Z", prefs.Z)
+            expect(data).not.toHaveProperty("T") // never touches the other identity
+            expect(options).toEqual({ merge: true })
+        })
+
+        it("writes the full map (merge) when no userId is given (first-time seed)", async () => {
+            await savePreferencesToFirestore(prefs)
+
+            const call = vi.mocked(firestore.setDoc).mock.calls[0]
+            const data = call[1] as Record<string, unknown>
+
+            expect(data).toHaveProperty("Z")
+            expect(data).toHaveProperty("T")
+            expect(call[2]).toEqual({ merge: true })
         })
     })
 })

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -107,12 +107,26 @@ export { deleteProfilePicture, uploadProfilePicture } from "./drive"
 // Preferences sync functions
 const PREFERENCES_DOC = "preferences/shared"
 
-export async function savePreferencesToFirestore(prefs: UserPreferencesMap): Promise<void> {
+/**
+ * Persist preferences to Firestore. When `userId` is given, only that user's
+ * entry is written (merge), so a device signed in as one identity can never
+ * overwrite the other identity's settings. Without `userId`, the full map is
+ * written (used only for first-time seeding).
+ */
+export async function savePreferencesToFirestore(
+    prefs: UserPreferencesMap,
+    userId?: UserId
+): Promise<void> {
     const docRef = doc(db, PREFERENCES_DOC)
-    await setDoc(docRef, {
-        ...prefs,
-        updatedAt: serverTimestamp(),
-    })
+    if (userId) {
+        await setDoc(
+            docRef,
+            { [userId]: prefs[userId], updatedAt: serverTimestamp() },
+            { merge: true }
+        )
+    } else {
+        await setDoc(docRef, { ...prefs, updatedAt: serverTimestamp() }, { merge: true })
+    }
 }
 
 export async function loadPreferencesFromFirestore(): Promise<UserPreferencesMap | null> {

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -3,9 +3,9 @@
   import PageHeader from '$lib/components/ui/PageHeader.svelte'
   import { deleteProfilePicture, logOut, uploadProfilePicture } from '$lib/firebase'
   import { hapticLight } from '$lib/haptics'
-  import { activeUser, currentPreferences, displayAbbreviations, immediateSavePreferences, userPreferences } from '$lib/stores/app'
+  import { activeUser, currentPreferences, displayAbbreviations, immediateSavePreferences, saveActiveUserPreferences, userPreferences } from '$lib/stores/app'
   import type { GeoLocation, LocationMode, NavMode, FontPreset, Theme, VideoSyncPlatform } from '$lib/types'
-  import { Camera, Info, Loader2, LogOut, MapPin, Moon, Palette, RefreshCw, Settings, Sun, User, Video, X, Download, ExternalLink as ExternalLinkIcon, Layout, Type, Sparkles } from 'lucide-svelte'
+  import { Camera, Info, Loader2, LogOut, MapPin, Moon, Palette, RefreshCw, Settings, Sun, User, Video, X, Download, ExternalLink as ExternalLinkIcon, Layout, Type, Sparkles, Save, Check as CheckIcon } from 'lucide-svelte'
   import { toast } from 'svelte-sonner'
   import { isYouTubeAPIConfigured, requestAccessToken } from '$lib/services/youtube-sync'
   import { ACCENT_PRESETS, DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from '$lib/accents'
@@ -60,6 +60,10 @@
       if (tapTimer) {
         clearTimeout(tapTimer)
         tapTimer = null
+      }
+      if (savedTimer) {
+        clearTimeout(savedTimer)
+        savedTimer = null
       }
     }
   })
@@ -352,6 +356,27 @@
 
   function handleSignatureChange(): void {
     savePreferences()
+  }
+
+  // Manual force-save of ONLY the active user's settings.
+  let isSavingSettings = $state(false)
+  let justSaved = $state(false)
+  let savedTimer: ReturnType<typeof setTimeout> | null = null
+  async function handleManualSave(): Promise<void> {
+    isSavingSettings = true
+    hapticLight()
+    try {
+      await saveActiveUserPreferences()
+      justSaved = true
+      if (savedTimer) clearTimeout(savedTimer)
+      savedTimer = setTimeout(() => { justSaved = false }, 2000)
+      toast.success(`Saved ${localName || $activeUser}'s settings`)
+    } catch (err) {
+      console.error('Manual save failed:', err)
+      toast.error('Failed to save settings')
+    } finally {
+      isSavingSettings = false
+    }
   }
 
   async function handleConnectYouTube(): Promise<void> {
@@ -1096,6 +1121,26 @@
         <Info size={16} />
         App
       </h2>
+
+      <!-- Manual save (active user's settings only) -->
+      <button
+        type="button"
+        class="btn-primary w-full"
+        onclick={handleManualSave}
+        disabled={isSavingSettings}
+      >
+        {#if isSavingSettings}
+          <Loader2 size={18} class="animate-spin" />
+          <span>Saving…</span>
+        {:else if justSaved}
+          <CheckIcon size={18} />
+          <span>Saved</span>
+        {:else}
+          <Save size={18} />
+          <span>Save {localName || $activeUser}'s settings</span>
+        {/if}
+      </button>
+      <p class="text-xs text-slate-400 -mt-2">Forces a sync of only the active profile's settings.</p>
 
       <!-- Update/Reload Button -->
       <button

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -45,7 +45,9 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         noteAutoToneShift: true,
         showIdentityPill: true,
         bottomTabs: [...DEFAULT_BOTTOM_TABS],
-        lastUpdated: Date.now(),
+        // 0 so an untouched default never wins the last-write-wins merge and
+        // clobbers real synced settings from another device.
+        lastUpdated: 0,
     },
     T: {
         theme: "light",
@@ -60,7 +62,9 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         noteAutoToneShift: true,
         showIdentityPill: true,
         bottomTabs: [...DEFAULT_BOTTOM_TABS],
-        lastUpdated: Date.now(),
+        // 0 so an untouched default never wins the last-write-wins merge and
+        // clobbers real synced settings from another device.
+        lastUpdated: 0,
     },
 }
 
@@ -202,11 +206,11 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
     return true
 }
 
-// Save with exponential backoff retry
-async function saveWithRetry(prefs: UserPreferencesMap, retries = 3): Promise<void> {
+// Save with exponential backoff retry. Only the given user's entry is written.
+async function saveWithRetry(prefs: UserPreferencesMap, userId: UserId, retries = 3): Promise<void> {
     for (let i = 0; i < retries; i++) {
         try {
-            await savePreferencesToFirestore(prefs)
+            await savePreferencesToFirestore(prefs, userId)
             return
         } catch (err) {
             if (i === retries - 1) {
@@ -220,17 +224,19 @@ async function saveWithRetry(prefs: UserPreferencesMap, retries = 3): Promise<vo
     }
 }
 
-// Debounced save to Firestore with retry
+// Debounced save to Firestore with retry — persists only the active user's
+// settings so we never overwrite the other identity's data on sync.
 function debouncedSaveToFirestore(prefs: UserPreferencesMap): void {
     if (isRemoteUpdate) return // Don't save if this was a remote update
 
+    const activeUserId = get(activeUser)
     if (syncDebounceTimer) clearTimeout(syncDebounceTimer)
     syncDebounceTimer = setTimeout(() => {
-        saveWithRetry(prefs)
+        saveWithRetry(prefs, activeUserId)
     }, 1000) // 1 second debounce
 }
 
-// Immediate save (no debounce) for critical updates like profile pictures
+// Immediate save (no debounce) for critical updates like profile pictures.
 export async function immediateSavePreferences(): Promise<void> {
     if (isRemoteUpdate) return
 
@@ -239,7 +245,18 @@ export async function immediateSavePreferences(): Promise<void> {
     const activeUserId = get(activeUser)
     prefs[activeUserId].lastUpdated = Date.now()
 
-    await saveWithRetry(prefs)
+    await saveWithRetry(prefs, activeUserId)
+}
+
+// Force-persist ONLY the active user's settings right now (manual save button).
+export async function saveActiveUserPreferences(): Promise<void> {
+    const activeUserId = get(activeUser)
+    userPreferences.update(p => {
+        if (p[activeUserId]) p[activeUserId].lastUpdated = Date.now()
+        return p
+    })
+    if (syncDebounceTimer) clearTimeout(syncDebounceTimer) // cancel any pending debounce
+    await saveWithRetry(get(userPreferences), activeUserId)
 }
 
 // Initialize Firestore sync (call after auth)
@@ -276,9 +293,10 @@ export async function initPreferencesSync(): Promise<void> {
             userPreferences.set(merged)
             isRemoteUpdate = false
         } else {
-            // No remote prefs yet, push local to Firestore
+            // No remote prefs yet — seed only the active user's entry so we
+            // don't stamp the other identity with this device's defaults.
             const localPrefs = get(userPreferences)
-            await savePreferencesToFirestore(localPrefs)
+            await savePreferencesToFirestore(localPrefs, get(activeUser))
         }
     } catch (err) {
         console.warn("Failed to load preferences from Firestore:", err)


### PR DESCRIPTION
First item from the roadmap (#64, "PR A") — a data-integrity fix.

## The bug
Signing in as one identity (say Z) could overwrite the **other** identity's (T's) settings with this device's stale/default copy on sync. Two root causes:

1. **Full-document overwrite.** `savePreferencesToFirestore` wrote the entire `{Z, T}` doc with `setDoc` (no merge). A Z device persisted its *local* copy of T too — so if that copy was stale/default, it clobbered T's real settings.
2. **Fresh default timestamps.** `DEFAULT_PREFERENCES.*.lastUpdated` was `Date.now()` evaluated at module load, so *default* entries carried a brand-new timestamp and could win the last-write-wins merge on the other device.

## The fix
- `savePreferencesToFirestore(prefs, userId?)` writes **only that user's field** with `{ merge: true }`. The debounced save, immediate save, and first-time seed all pass the **active** user — so a device only ever writes the identity it's signed in as. (This is your "only persist the active user's settings" ask.)
- `DEFAULT_PREFERENCES.*.lastUpdated = 0`, so an untouched default never wins the merge and can't propagate defaults across devices.
- New `saveActiveUserPreferences()` + a **"Save <name>'s settings"** button in **Settings → App** to force-persist the active profile immediately (cancels any pending debounce, bumps its timestamp).

## Note on already-corrupted data
This prevents *future* clobbering. Anything already overwritten server-side won't auto-restore — re-enter those settings and hit the new Save button to re-persist them authoritatively.

## Verification
- `bun run check` — 0 errors, 0 warnings
- `bun run build` — succeeds
- `bun test:run` — **276 passing** (2 new tests asserting active-user-only merge writes)

Next in the roadmap: custom image overrides (PR B) and the Places "Failed to fetch" quick fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_