### PR TITLE
[B] Custom image overrides for media &amp; videos

### DIFF
--- a/src/lib/components/MediaDetailModal.svelte
+++ b/src/lib/components/MediaDetailModal.svelte
@@ -20,6 +20,7 @@
   let editedNotes = $state('');
   let newComment = $state('');
   let watchDateInput = $state('');
+  let editedImageOverride = $state('');
   
   // Non-reactive tracking - prevents effect from creating dependencies on local form state
   let previousMediaId: string | undefined = undefined;
@@ -32,7 +33,8 @@
       // Only sync when viewing a different media item
       if (media.id !== previousMediaId) {
         editedNotes = media.notes || '';
-        
+        editedImageOverride = media.imageOverride || '';
+
         if (media.watchDate) {
           const d = new Date(media.watchDate.toDate());
           const year = d.getFullYear();
@@ -75,6 +77,15 @@
   async function updateNotes(): Promise<void> {
     if (!media?.id) return;
     await updateDocument<Media>('media', media.id, { notes: editedNotes }, $activeUser);
+  }
+
+  async function updateImageOverride(): Promise<void> {
+    if (!media?.id) return;
+    await updateDocument<Media>('media', media.id, { imageOverride: editedImageOverride.trim() }, $activeUser);
+  }
+  function clearImageOverride(): void {
+    editedImageOverride = '';
+    updateImageOverride();
   }
 
   async function updateStatus(status: MediaStatus): Promise<void> {
@@ -146,9 +157,9 @@
     {#snippet header()}
       <!-- Header with poster -->
       <div class="relative shrink-0">
-        {#if media.posterPath}
+        {#if media.imageOverride || media.posterPath}
           <img
-            src={posterUrl(media.posterPath)}
+            src={posterUrl(media.imageOverride || media.posterPath)}
             alt={media.title}
             loading="lazy"
             class="w-full h-48 object-cover rounded-t-xl"
@@ -326,6 +337,25 @@
           </div>
         {/if}
         
+        <!-- Custom image override -->
+        <div>
+          <label for="media-image-override" class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Custom image URL</label>
+          <div class="flex gap-2">
+            <input
+              id="media-image-override"
+              type="url"
+              bind:value={editedImageOverride}
+              onblur={updateImageOverride}
+              placeholder="https://…  (overrides the poster)"
+              class="flex-1 p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
+            />
+            {#if editedImageOverride}
+              <button type="button" class="btn-icon-sm touch-sm" onclick={clearImageOverride} aria-label="Clear custom image">✕</button>
+            {/if}
+          </div>
+          <p class="text-xs text-slate-400 mt-1">Use when the poster exists but won't load.</p>
+        </div>
+
         <!-- Notes -->
         <div>
           <label for="media-notes" class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Personal Notes</label>

--- a/src/lib/components/VideoDetailModal.svelte
+++ b/src/lib/components/VideoDetailModal.svelte
@@ -18,6 +18,7 @@
   let editedNotes = $state('');
   let newComment = $state('');
   let watchedDateInput = $state('');
+  let editedImageOverride = $state('');
   
   // Non-reactive tracking
   let previousVideoId: string | undefined = undefined;
@@ -29,7 +30,8 @@
     if (video) {
       if (video.id !== previousVideoId) {
         editedNotes = video.notes || '';
-        
+        editedImageOverride = video.imageOverride || '';
+
         if (video.watchedDate) {
           watchedDateInput = new Date(video.watchedDate.toDate()).toISOString().split('T')[0];
         } else {
@@ -57,6 +59,15 @@
   async function updateNotes(): Promise<void> {
     if (!video?.id) return;
     await updateDocument<Video>('videos', video.id, { notes: editedNotes }, $activeUser);
+  }
+
+  async function updateImageOverride(): Promise<void> {
+    if (!video?.id) return;
+    await updateDocument<Video>('videos', video.id, { imageOverride: editedImageOverride.trim() }, $activeUser);
+  }
+  function clearImageOverride(): void {
+    editedImageOverride = '';
+    updateImageOverride();
   }
 
   async function updateStatus(status: VideoStatus): Promise<void> {
@@ -302,6 +313,26 @@
               </p>
             </div>
           {/if}
+        </div>
+
+        <!-- Custom image override -->
+        <div class="p-6 border-b border-[var(--color-border)]">
+          <label for="video-image-override" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+            Custom thumbnail URL
+          </label>
+          <div class="flex gap-2">
+            <input
+              id="video-image-override"
+              type="url"
+              bind:value={editedImageOverride}
+              onblur={updateImageOverride}
+              placeholder="https://…  (overrides the thumbnail)"
+              class="flex-1 p-2 text-sm bg-slate-50 dark:bg-slate-800 border border-[var(--color-border)] rounded-lg focus:outline-none focus:border-accent"
+            />
+            {#if editedImageOverride}
+              <button type="button" class="btn-icon-sm touch-sm" onclick={clearImageOverride} aria-label="Clear custom thumbnail">✕</button>
+            {/if}
+          </div>
         </div>
 
         <!-- Notes -->

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -733,9 +733,9 @@
               onclick={() => selectedMedia = item}
             >
               <div class="aspect-[2/3] bg-slate-100 dark:bg-slate-800 relative">
-                {#if item.posterPath}
+                {#if item.imageOverride || item.posterPath}
                   <img
-                    src={posterUrl(item.posterPath, 'md')}
+                    src={item.imageOverride || posterUrl(item.posterPath, 'md')}
                     alt={item.title}
                     loading="lazy"
                     class="w-full h-full object-cover"

--- a/src/lib/pages/Videos.svelte
+++ b/src/lib/pages/Videos.svelte
@@ -401,9 +401,9 @@
               onclick={() => openVideoDetail(video)}
               class="relative w-full aspect-video bg-slate-100 dark:bg-slate-900 overflow-hidden group"
             >
-              {#if video.thumbnailUrl}
+              {#if video.imageOverride || video.thumbnailUrl}
                 <img
-                  src={video.thumbnailUrl}
+                  src={video.imageOverride || video.thumbnailUrl}
                   alt={video.title}
                   class="w-full h-full object-cover group-hover:scale-105 transition-transform"
                 />

--- a/src/lib/pages/home/InProgressSection.svelte
+++ b/src/lib/pages/home/InProgressSection.svelte
@@ -38,9 +38,9 @@
             class="flex-shrink-0 w-24 touch-manipulation"
             onclick={() => onItemClick(item)}
           >
-            {#if item.posterPath}
+            {#if item.imageOverride || item.posterPath}
               <img
-                src="https://image.tmdb.org/t/p/w154{item.posterPath}"
+                src={item.imageOverride || `https://image.tmdb.org/t/p/w154${item.posterPath}`}
                 alt={item.title}
                 class="w-24 h-36 object-cover rounded-xl shadow-md"
               />

--- a/src/lib/pages/home/RecentActivityFeed.svelte
+++ b/src/lib/pages/home/RecentActivityFeed.svelte
@@ -53,9 +53,9 @@
             class="w-full flex items-center gap-3 px-3 py-3 rounded-xl bg-surface border border-[var(--color-border)] hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors touch-manipulation text-left"
             onclick={() => onItemClick(item)}
           >
-            {#if item.posterPath}
+            {#if item.imageOverride || item.posterPath}
               <img
-                src="https://image.tmdb.org/t/p/w92{item.posterPath}"
+                src={item.imageOverride || `https://image.tmdb.org/t/p/w92${item.posterPath}`}
                 alt={item.title}
                 class="w-10 h-10 rounded-lg object-cover flex-shrink-0"
               />

--- a/src/lib/stores/home.ts
+++ b/src/lib/stores/home.ts
@@ -37,6 +37,7 @@ function rebuildActivity(): void {
         actor: m.updatedBy ?? m.createdBy,
         updatedAt: m.updatedAt,
         posterPath: m.posterPath,
+        imageOverride: m.imageOverride,
         mediaType: m.type,
     }))
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,6 +131,7 @@ export interface Media extends BaseDocument {
     steamId?: number
     title: string
     posterPath: string | null
+    imageOverride?: string // Manual full-URL image override when the source poster won't display
     releaseDate?: string
     overview?: string
     status: MediaStatus
@@ -306,6 +307,7 @@ export interface Video extends BaseDocument {
     url: string
     videoId: string // YouTube video ID
     thumbnailUrl?: string
+    imageOverride?: string // Manual full-URL image override when the source thumbnail won't display
     duration?: string // e.g., "10:23"
     channelName?: string
     status: VideoStatus
@@ -378,5 +380,6 @@ export interface HomeActivity {
     actor: UserId           // Who performed the most recent activity (updatedBy ?? createdBy)
     updatedAt: Timestamp
     posterPath?: string | null // Media poster, if available
+    imageOverride?: string     // Manual image override, if set
     mediaType?: MediaType      // Only set when type === "media"
 }


### PR DESCRIPTION
Child PR (stacks onto the parent PR branch). Closes #66.

When a source poster/thumbnail exists but won't display (e.g. Marvel Rivals), an item can carry a manual full-URL **image override** that takes precedence.

- `Media` and `Video` gain an optional `imageOverride`.
- Render sites prefer the override: **Library grid**, **Media/Video detail modals**, **Home** in-progress + recent-activity (via `HomeActivity`).
- Detail modals get a **"Custom image/thumbnail URL"** input (save-on-blur + clear).

Verified: check 0/0, build ok, 276 tests. Merges into the parent branch `claude/redesign-issues-polish-08sj1c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_