### PR TITLE
[C] Nav IA: fold Search into Media, Profiles into the identity pill, flatten tabs

### DIFF
--- a/src/lib/components/BottomTabBar.svelte
+++ b/src/lib/components/BottomTabBar.svelte
@@ -2,7 +2,7 @@
   import { MoreHorizontal } from 'lucide-svelte'
   import { navMode } from '$lib/stores/nav'
   import { currentPreferences } from '$lib/stores/app'
-  import { TAB_DEFS, resolveTabs, type TabDef } from '$lib/tabs'
+  import { TAB_DEFS, resolveTabs, clampMaxTabsShown, type TabDef } from '$lib/tabs'
   import BottomSheet from './ui/BottomSheet.svelte'
 
   interface Props {
@@ -14,12 +14,16 @@
 
   let moreOpen = $state(false)
 
-  // Primary tabs come from the user's configuration; everything else falls
-  // into the "More" sheet.
-  let primaryTabs = $derived(resolveTabs($currentPreferences?.bottomTabs))
+  // Chosen tabs come from the user's config; the first `maxTabsShown` render in
+  // the bar and any remainder (plus unchosen destinations) spill into "More".
+  let chosenTabs = $derived(resolveTabs($currentPreferences?.bottomTabs))
+  let maxShown = $derived(clampMaxTabsShown($currentPreferences?.maxTabsShown))
+  let primaryTabs = $derived(chosenTabs.slice(0, maxShown))
   let moreItems = $derived.by(() => {
     const shown = new Set(primaryTabs.map(t => t.key))
-    return TAB_DEFS.filter(t => !shown.has(t.key))
+    const overflow = chosenTabs.slice(maxShown)
+    const unchosen = TAB_DEFS.filter(t => !chosenTabs.some(c => c.key === t.key))
+    return [...overflow, ...unchosen].filter(t => !shown.has(t.key))
   })
 
   function isActive(tab: TabDef): boolean {

--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { activeUser, displayAbbreviations, userPreferences } from '$lib/stores/app'
+  import { Heart, User } from 'lucide-svelte'
+  import { activeUser, displayAbbreviations, displayNames, userPreferences } from '$lib/stores/app'
+  import { navigate } from '$lib/stores/nav'
   import { hapticLight } from '$lib/haptics'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { UserId } from '$lib/types'
@@ -112,6 +114,16 @@
     isExpanded = false
   }
 
+  function goProfiles(e: MouseEvent, view: 'mine' | 'theirs'): void {
+    e.stopPropagation()
+    if (justDragged) return
+    hapticLight()
+    navigate(`/profiles?view=${view}`)
+    isExpanded = false
+  }
+
+  let otherUser = $derived<UserId>($activeUser === 'Z' ? 'T' : 'Z')
+
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape' && isExpanded) {
       isExpanded = false
@@ -141,26 +153,50 @@
   onpointercancel={onPointerUp}
 >
   {#if isExpanded}
-    <!-- Expanded picker -->
+    <!-- Expanded panel: switch identity + profile access -->
     <div
-      class="flex items-center gap-1 p-1 rounded-full bg-surface border border-[var(--color-border)] shadow-lg"
-      role="listbox"
-      aria-label="Switch user"
+      class="flex flex-col gap-2 p-2 rounded-2xl bg-surface border border-[var(--color-border)] shadow-xl w-52"
+      role="dialog"
+      aria-label="Identity and profiles"
     >
-      {#each users as userId (userId)}
-        {@const prefs = $userPreferences[userId]}
-        <button
-          type="button"
-          role="option"
-          aria-selected={$activeUser === userId}
-          class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold transition-transform hover:scale-105 touch-manipulation
-            {$activeUser === userId ? 'ring-2 ring-offset-1 ring-accent' : ''}"
-          style:background-color={prefs?.accentColor ?? DEFAULT_ACCENT}
-          onclick={(e) => selectUser(e, userId)}
-        >
-          {$displayAbbreviations[userId]}
-        </button>
-      {/each}
+      <div class="flex items-center gap-2" role="listbox" aria-label="Switch user">
+        {#each users as userId (userId)}
+          {@const prefs = $userPreferences[userId]}
+          <button
+            type="button"
+            role="option"
+            aria-selected={$activeUser === userId}
+            class="flex-1 flex items-center gap-2 p-1.5 rounded-xl transition-colors touch-manipulation
+              {$activeUser === userId ? 'bg-accent/10' : 'hover:bg-slate-100 dark:hover:bg-slate-800'}"
+            onclick={(e) => selectUser(e, userId)}
+          >
+            <span
+              class="w-9 h-9 rounded-full flex items-center justify-center text-white text-sm font-bold shrink-0 {$activeUser === userId ? 'ring-2 ring-offset-1 ring-accent' : ''}"
+              style:background-color={prefs?.accentColor ?? DEFAULT_ACCENT}
+            >{$displayAbbreviations[userId]}</span>
+            <span class="text-sm font-medium truncate">{$displayNames[userId]}</span>
+          </button>
+        {/each}
+      </div>
+
+      <div class="h-px bg-[var(--color-border)]"></div>
+
+      <button
+        type="button"
+        class="flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-left text-sm font-medium transition-colors touch-manipulation hover:bg-slate-100 dark:hover:bg-slate-800"
+        onclick={(e) => goProfiles(e, 'mine')}
+      >
+        <User size={16} class="text-accent" />
+        My keepsakes
+      </button>
+      <button
+        type="button"
+        class="flex items-center gap-2.5 px-2.5 py-2 rounded-xl text-left text-sm font-medium transition-colors touch-manipulation hover:bg-slate-100 dark:hover:bg-slate-800"
+        onclick={(e) => goProfiles(e, 'theirs')}
+      >
+        <Heart size={16} class="text-accent" />
+        {$displayNames[otherUser]}'s keepsakes
+      </button>
     </div>
   {:else}
     <!-- Collapsed trigger (tap to switch, hold and drag to move) -->

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,7 +4,6 @@
   import { hapticLight } from '$lib/haptics'
   import { getIOSCompatibleImageUrl } from '$lib/ios-images'
   import {
-    Search,
     Library,
     Film,
     Tv,
@@ -17,7 +16,6 @@
     X,
     LogOut,
     ChevronRight,
-    Heart,
     Home
   } from 'lucide-svelte'
 
@@ -116,11 +114,9 @@
 
   const navItems = [
     { path: '/', label: 'Home', icon: Home },
-    { path: '/search', label: 'Search', icon: Search },
     { path: '/videos', label: 'Videos', icon: Video },
     { path: '/notes', label: 'Notes', icon: StickyNote },
     { path: '/places', label: 'Places', icon: MapPin },
-    { path: '/profiles', label: 'Profiles', icon: Heart },
   ]
 
   const libraryItems = [

--- a/src/lib/pages/Home.svelte
+++ b/src/lib/pages/Home.svelte
@@ -37,7 +37,7 @@
   }
 
   function handleAddMedia(): void {
-    navigate('/search?discover=1')
+    navigate('/library/movies?add=1')
   }
 </script>
 

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -19,6 +19,7 @@
     type SortField,
   } from '$lib/filters'
   import { onMount } from 'svelte'
+  import { consumeQueryParam } from '$lib/stores/nav'
   import MediaDetailModal from '$lib/components/MediaDetailModal.svelte'
   import IconButton from '$lib/components/ui/IconButton.svelte'
   import EmptyState from '$lib/components/ui/EmptyState.svelte'
@@ -86,6 +87,9 @@
   const libraryTypes: MediaType[] = ['movie', 'tv', 'game']
 
   onMount(() => {
+    // Open the add/discover panel directly when arriving via a quick-add link.
+    if (consumeQueryParam('add') !== null) showAddPanel = true
+
     unsubscribe = subscribeToCollection<Media>('media', (items) => {
       media = items
       if (selectedMedia) {
@@ -500,12 +504,6 @@
     </button>
 
     <div class="flex items-center gap-1">
-      <IconButton
-        icon={Search}
-        label="Search"
-        onclick={() => navigate('/')}
-      />
-
       <IconButton label="Change grid size" onclick={cycleGridSize}>
         {#snippet children()}
           <span class="text-xs font-mono">{gridSizeIcons[$mediaGridSize]}</span>

--- a/src/lib/pages/Profiles.svelte
+++ b/src/lib/pages/Profiles.svelte
@@ -7,6 +7,7 @@
   import { hapticLight, hapticSuccess } from '$lib/haptics'
   import { activeUser, displayNames, userPreferences } from '$lib/stores/app'
   import { DEFAULT_ACCENT } from '$lib/accents'
+  import { consumeQueryParam } from '$lib/stores/nav'
   import type { ProfileItem, ProfileCategory, UserId } from '$lib/types'
   import { Heart, Pencil, Plus, Star, Trash2, Gift, Coffee, Music, Film, BookOpen, Zap, Sparkles, Palette, Users, MapPin, Utensils } from 'lucide-svelte'
   import { onMount } from 'svelte'
@@ -51,6 +52,10 @@
   let viewMode = $state<ViewMode>('both')
 
   onMount(() => {
+    // Arriving from the identity pill: /profiles?view=mine|theirs
+    const view = consumeQueryParam('view')
+    if (view === 'mine' || view === 'theirs' || view === 'both') viewMode = view
+
     unsubscribe = subscribeToCollection<ProfileItem>('profiles', (items) => {
       profileItems = items
     })

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -9,7 +9,7 @@
   import { toast } from 'svelte-sonner'
   import { isYouTubeAPIConfigured, requestAccessToken } from '$lib/services/youtube-sync'
   import { ACCENT_PRESETS, DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from '$lib/accents'
-  import { TAB_DEFS, DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS, tabDef } from '$lib/tabs'
+  import { TAB_DEFS, DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN, MAX_TABS_SHOWN, clampMaxTabsShown, tabDef } from '$lib/tabs'
   import { ArrowUp, ArrowDown, Minus, Plus as PlusIcon } from 'lucide-svelte'
 
   interface Props {
@@ -39,6 +39,7 @@
   let localNoteAutoToneShift = $state(true)
   let localShowIdentityPill = $state(true)
   let localBottomTabs = $state<string[]>([])
+  let localMaxTabsShown = $state(DEFAULT_MAX_TABS_SHOWN)
 
   // App state
   let isReloading = $state(false)
@@ -108,6 +109,7 @@
       localNoteAutoToneShift = $currentPreferences.noteAutoToneShift ?? true
       localShowIdentityPill = $currentPreferences.showIdentityPill ?? true
       localBottomTabs = [...($currentPreferences.bottomTabs ?? DEFAULT_BOTTOM_TABS)]
+      localMaxTabsShown = clampMaxTabsShown($currentPreferences.maxTabsShown)
       previousUser = $activeUser
     }
   })
@@ -208,6 +210,7 @@
         noteAutoToneShift: localNoteAutoToneShift,
         showIdentityPill: localShowIdentityPill,
         bottomTabs: [...localBottomTabs],
+        maxTabsShown: localMaxTabsShown,
         lastUpdated: Date.now()
       }
     }))
@@ -325,9 +328,15 @@
   let availableTabs = $derived(TAB_DEFS.filter(t => !localBottomTabs.includes(t.key)))
 
   function addBottomTab(key: string): void {
-    if (localBottomTabs.length >= MAX_BOTTOM_TABS || localBottomTabs.includes(key)) return
+    if (localBottomTabs.includes(key)) return
     hapticLight()
     localBottomTabs = [...localBottomTabs, key]
+    savePreferences()
+  }
+
+  function handleMaxTabsChange(n: number): void {
+    hapticLight()
+    localMaxTabsShown = clampMaxTabsShown(n)
     savePreferences()
   }
 
@@ -947,7 +956,21 @@
             <span class="text-sm font-medium">Bottom bar tabs</span>
             <button type="button" class="text-xs text-accent" onclick={resetBottomTabs}>Reset</button>
           </div>
-          <p class="text-xs text-slate-400 mb-3">Choose up to {MAX_BOTTOM_TABS} tabs and drag their order with the arrows. The rest live under "More".</p>
+          <p class="text-xs text-slate-400 mb-3">Order your tabs with the arrows; anything beyond the limit below lives under "More".</p>
+
+          <!-- Max tabs shown -->
+          <div class="flex items-center justify-between mb-3">
+            <span class="text-sm">Tabs shown before "More"</span>
+            <div class="flex items-center gap-2">
+              <button type="button" class="btn-icon-sm touch-sm disabled:opacity-30" disabled={localMaxTabsShown <= 2} onclick={() => handleMaxTabsChange(localMaxTabsShown - 1)} aria-label="Fewer tabs">
+                <Minus size={16} />
+              </button>
+              <span class="w-5 text-center text-sm font-semibold tabular-nums">{localMaxTabsShown}</span>
+              <button type="button" class="btn-icon-sm touch-sm disabled:opacity-30" disabled={localMaxTabsShown >= MAX_TABS_SHOWN} onclick={() => handleMaxTabsChange(localMaxTabsShown + 1)} aria-label="More tabs">
+                <PlusIcon size={16} />
+              </button>
+            </div>
+          </div>
 
           <!-- On the bar (ordered) -->
           <ul class="space-y-2 mb-3">
@@ -998,8 +1021,7 @@
                 {@const TabIcon = def.icon}
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1.5 pl-2.5 pr-3 py-1.5 rounded-full border border-[var(--color-border)] text-sm font-medium disabled:opacity-40 hover:border-accent transition-colors touch-manipulation"
-                  disabled={localBottomTabs.length >= MAX_BOTTOM_TABS}
+                  class="inline-flex items-center gap-1.5 pl-2.5 pr-3 py-1.5 rounded-full border border-[var(--color-border)] text-sm font-medium hover:border-accent transition-colors touch-manipulation"
                   onclick={() => addBottomTab(def.key)}
                 >
                   <TabIcon size={15} />
@@ -1008,9 +1030,6 @@
                 </button>
               {/each}
             </div>
-            {#if localBottomTabs.length >= MAX_BOTTOM_TABS}
-              <p class="text-xs text-slate-400 mt-2">Remove a tab to add another (max {MAX_BOTTOM_TABS}).</p>
-            {/if}
           {/if}
         </div>
       {/if}

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -7,7 +7,7 @@ import {
 } from "../firebase"
 import type { UserId, UserPreferences, UserPreferencesMap } from "../types"
 import { DEFAULT_ACCENT_Z, DEFAULT_ACCENT_T } from "../accents"
-import { DEFAULT_BOTTOM_TABS } from "../tabsConfig"
+import { DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN } from "../tabsConfig"
 
 // Touch device detection store
 // Uses pointer: coarse media query which is more reliable than touch event detection
@@ -45,6 +45,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         noteAutoToneShift: true,
         showIdentityPill: true,
         bottomTabs: [...DEFAULT_BOTTOM_TABS],
+        maxTabsShown: DEFAULT_MAX_TABS_SHOWN,
         // 0 so an untouched default never wins the last-write-wins merge and
         // clobbers real synced settings from another device.
         lastUpdated: 0,
@@ -62,6 +63,7 @@ const DEFAULT_PREFERENCES: UserPreferencesMap = {
         noteAutoToneShift: true,
         showIdentityPill: true,
         bottomTabs: [...DEFAULT_BOTTOM_TABS],
+        maxTabsShown: DEFAULT_MAX_TABS_SHOWN,
         // 0 so an untouched default never wins the last-write-wins merge and
         // clobbers real synced settings from another device.
         lastUpdated: 0,
@@ -155,6 +157,7 @@ function prefsEqual(a: UserPreferencesMap, b: UserPreferencesMap): boolean {
         "noteAutoToneShift",
         "showIdentityPill",
         "bottomTabs",
+        "maxTabsShown",
     ]
 
     for (const userId of ["Z", "T"] as const) {

--- a/src/lib/tabs.ts
+++ b/src/lib/tabs.ts
@@ -1,13 +1,13 @@
 // Canonical registry of navigable destinations that can appear in the bottom
 // tab bar. The bar is user-configurable: `bottomTabs` in preferences is an
-// ordered list of these keys shown as primary tabs; everything else falls into
-// the "More" sheet.
+// ordered list of these keys; the first `maxTabsShown` render in the bar and
+// any remainder (plus unchosen destinations) spill into the "More" sheet.
 
 import type { ComponentType } from "svelte"
-import { Home, Library, StickyNote, MapPin, Search, Video, Heart, Settings } from "lucide-svelte"
-import { DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS } from "./tabsConfig"
+import { Home, Library, StickyNote, MapPin, Video, Settings } from "lucide-svelte"
+import { DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN, MAX_TABS_SHOWN } from "./tabsConfig"
 
-export { DEFAULT_BOTTOM_TABS, MAX_BOTTOM_TABS }
+export { DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN, MAX_TABS_SHOWN }
 
 export interface TabDef {
     key: string
@@ -17,14 +17,13 @@ export interface TabDef {
     matchPrefix?: string // active when the route starts with this (e.g. /library)
 }
 
+// Search folded into Media discovery; Profiles moved into the identity pill.
 export const TAB_DEFS: TabDef[] = [
     { key: "home", label: "Home", path: "/", icon: Home },
     { key: "media", label: "Media", path: "/library/movies", icon: Library, matchPrefix: "/library" },
     { key: "notes", label: "Notes", path: "/notes", icon: StickyNote },
     { key: "places", label: "Places", path: "/places", icon: MapPin },
-    { key: "search", label: "Search", path: "/search", icon: Search },
     { key: "videos", label: "Videos", path: "/videos", icon: Video },
-    { key: "profiles", label: "Profiles", path: "/profiles", icon: Heart },
     { key: "settings", label: "Settings", path: "/settings", icon: Settings },
 ]
 
@@ -32,7 +31,7 @@ export function tabDef(key: string): TabDef | undefined {
     return TAB_DEFS.find(t => t.key === key)
 }
 
-/** Resolve a stored key list into valid, de-duplicated tab defs. */
+/** Resolve a stored key list into valid, de-duplicated tab defs (full chosen set). */
 export function resolveTabs(keys: string[] | undefined): TabDef[] {
     const source = keys && keys.length > 0 ? keys : DEFAULT_BOTTOM_TABS
     const seen = new Set<string>()
@@ -45,5 +44,10 @@ export function resolveTabs(keys: string[] | undefined): TabDef[] {
             seen.add(key)
         }
     }
-    return out.slice(0, MAX_BOTTOM_TABS)
+    return out
+}
+
+export function clampMaxTabsShown(n: number | undefined): number {
+    const v = Math.round(n ?? DEFAULT_MAX_TABS_SHOWN)
+    return Math.min(MAX_TABS_SHOWN, Math.max(2, v))
 }

--- a/src/lib/tabsConfig.ts
+++ b/src/lib/tabsConfig.ts
@@ -1,8 +1,12 @@
 // Pure tab configuration constants — no icon/component imports, so this stays
 // cheap to pull into stores (e.g. app.ts) without dragging in lucide-svelte.
 
-// Default primary tabs (in order). Media is on the bar by default.
-export const DEFAULT_BOTTOM_TABS = ["home", "media", "notes", "places"]
+// Default primary tabs (in order). Search moved into Media discovery and
+// Profiles moved into the identity pill, leaving six first-class destinations.
+export const DEFAULT_BOTTOM_TABS = ["home", "media", "notes", "places", "videos", "settings"]
 
-// A sensible ceiling so the bar (plus the "More" button) stays tappable.
-export const MAX_BOTTOM_TABS = 5
+// How many chosen tabs render in the bar before the rest spill into "More".
+export const DEFAULT_MAX_TABS_SHOWN = 6
+
+// Hard ceiling (equals the number of tab destinations).
+export const MAX_TABS_SHOWN = 6

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export interface UserPreferences {
     noteAutoToneShift?: boolean // Auto hue-shift note palette when both accents collide (default true)
     showIdentityPill?: boolean // Show the floating identity switcher (default true)
     bottomTabs?: string[] // Ordered tab keys shown in the bottom bar (rest go under "More")
+    maxTabsShown?: number // How many chosen tabs render before overflowing to "More"
 }
 
 export type UserPreferencesMap = Record<UserId, UserPreferences>


### PR DESCRIPTION
Child PR (stacks onto the parent). Closes #67.

- **Tab registry → six destinations** (Home, Media, Notes, Places, Videos, Settings). Search & Profiles are no longer tab candidates.
- **Discovery folded into Media**: Home's "Add Media" opens the Media add/discover panel (`/library/movies?add=1`), consumed by Library.
- **Profiles → identity pill**: the expanded pill is now a small panel — switch identity + "My keepsakes" / "&lt;other&gt;'s keepsakes" (→ `/profiles?view=…`, consumed by Profiles).
- **Configurable "tabs shown before More"**: new `maxTabsShown` pref (2–6, default 6) with a stepper in Settings. With six items + default, there's **no "More"** at all; lower it and the overflow spills into More.
- Sidebar drops Search & Profiles; Library toolbar drops the stray Search button. `/search` and `/profiles` routes still resolve when navigated to.

Verified: check 0/0, build ok, 276 tests. Merges into the parent branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_