### PR TITLE
[D] Global touch reactivity + cozier Home

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -157,8 +157,14 @@
 
 :root[data-reduce-motion] button:active,
 :root[data-reduce-motion] [role="button"]:active,
-:root[data-reduce-motion] .touch-feedback:active {
+:root[data-reduce-motion] a:active,
+:root[data-reduce-motion] label:active,
+:root[data-reduce-motion] .touch-feedback:active,
+:root[data-reduce-motion] .card:active,
+:root[data-reduce-motion] .keepsake:active,
+:root[data-reduce-motion] .quick-add:active {
   transform: none !important;
+  filter: none !important;
 }
 
 /* Touch device enhancements */
@@ -214,14 +220,34 @@
     min-height: 44px;
   }
 
-  /* Add active feedback to all buttons */
+  /* Active feedback — touch is the common case, so give elements a tactile
+     response that varies by kind. */
   button,
-  [role="button"] {
-    transition: transform 75ms ease-out;
+  [role="button"],
+  a,
+  label,
+  summary {
+    transition: transform 90ms ease-out, filter 90ms ease-out;
   }
   button:active,
-  [role="button"]:active {
+  [role="button"]:active,
+  a:active,
+  label:active {
     transform: scale(0.97);
+  }
+  /* Filled buttons dip in brightness rather than only shrinking. */
+  .btn-primary:active,
+  .btn-danger:active,
+  .rail-pen:active,
+  .pin-btn:active,
+  .quick-add-plus:active {
+    filter: brightness(0.93);
+  }
+  /* Surfaces press in gently (subtler than buttons). */
+  .card:active,
+  .keepsake:active,
+  .quick-add:active {
+    transform: scale(0.985);
   }
 
   /* Increase spacing in navigation and lists for easier tapping */

--- a/src/lib/pages/home/HomeGreeting.svelte
+++ b/src/lib/pages/home/HomeGreeting.svelte
@@ -1,23 +1,80 @@
 <script lang="ts">
+  import { Sun, Sunrise, Sunset, Moon } from 'lucide-svelte'
+
   interface Props {
     userName: string
   }
 
   let { userName }: Props = $props()
 
-  function getGreeting(): string {
+  function partOfDay(): { greeting: string; icon: typeof Sun } {
     const hour = new Date().getHours()
-    if (hour >= 5 && hour < 12) return 'Good morning'
-    if (hour >= 12 && hour < 18) return 'Good afternoon'
-    if (hour >= 18 && hour < 22) return 'Good evening'
-    return 'Good night'
+    if (hour >= 5 && hour < 12) return { greeting: 'Good morning', icon: Sunrise }
+    if (hour >= 12 && hour < 18) return { greeting: 'Good afternoon', icon: Sun }
+    if (hour >= 18 && hour < 22) return { greeting: 'Good evening', icon: Sunset }
+    return { greeting: 'Good night', icon: Moon }
   }
 
-  let greeting = $derived(getGreeting())
+  let today = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
+  let part = $derived(partOfDay())
 </script>
 
-<div class="py-2">
-  <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-50">
-    {greeting}, {userName}
-  </h1>
+<div class="hearth">
+  <div class="hearth-icon">
+    {#key part.greeting}
+      {@const Icon = part.icon}
+      <Icon size={20} />
+    {/key}
+  </div>
+  <div class="min-w-0">
+    <p class="hearth-eyebrow">{today}</p>
+    <h1 class="hearth-title">{part.greeting}, {userName}</h1>
+    <p class="hearth-sub">Here's what's new between us.</p>
+  </div>
 </div>
+
+<style>
+  .hearth {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: 1.1rem 1.2rem;
+    border-radius: 1.1rem;
+    background:
+      radial-gradient(120% 160% at 0% 0%, color-mix(in srgb, var(--color-accent) 16%, var(--color-surface)) 0%, var(--color-surface) 60%);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 8px 20px rgba(0,0,0,0.05);
+  }
+  .hearth-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 50%;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: #fff;
+    background: var(--color-accent);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--color-accent) 45%, transparent);
+  }
+  .hearth-eyebrow {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-hint, #78716c);
+    margin-bottom: 0.05rem;
+  }
+  .hearth-title {
+    font-size: 1.45rem;
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    color: var(--color-text);
+    text-wrap: balance;
+  }
+  .hearth-sub {
+    font-size: 0.82rem;
+    color: var(--color-text-muted, #57534e);
+    margin-top: 0.1rem;
+  }
+</style>

--- a/src/lib/pages/home/QuickAddBar.svelte
+++ b/src/lib/pages/home/QuickAddBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { StickyNote, MapPin, Film } from 'lucide-svelte'
+  import { StickyNote, MapPin, Film, Plus } from 'lucide-svelte'
 
   interface Props {
     onAddNote: () => void
@@ -8,31 +8,77 @@
   }
 
   let { onAddNote, onAddPlace, onAddMedia }: Props = $props()
+
+  const actions = [
+    { key: 'note', label: 'New note', icon: StickyNote },
+    { key: 'place', label: 'New place', icon: MapPin },
+    { key: 'media', label: 'Add media', icon: Film },
+  ] as const
+
+  function run(key: string): void {
+    if (key === 'note') onAddNote()
+    else if (key === 'place') onAddPlace()
+    else onAddMedia()
+  }
 </script>
 
-<div class="flex gap-2">
-  <button
-    type="button"
-    class="btn-primary flex-1 text-sm rounded-full py-2"
-    onclick={onAddNote}
-  >
-    <StickyNote size={16} />
-    Note
-  </button>
-  <button
-    type="button"
-    class="btn-primary flex-1 text-sm rounded-full py-2"
-    onclick={onAddPlace}
-  >
-    <MapPin size={16} />
-    Place
-  </button>
-  <button
-    type="button"
-    class="btn-primary flex-1 text-sm rounded-full py-2"
-    onclick={onAddMedia}
-  >
-    <Film size={16} />
-    Media
-  </button>
+<div class="grid grid-cols-3 gap-2.5">
+  {#each actions as a (a.key)}
+    {@const Icon = a.icon}
+    <button type="button" class="quick-add touch-feedback" onclick={() => run(a.key)}>
+      <span class="quick-add-chip">
+        <Icon size={18} />
+        <span class="quick-add-plus"><Plus size={11} strokeWidth={3} /></span>
+      </span>
+      <span class="quick-add-label">{a.label}</span>
+    </button>
+  {/each}
 </div>
+
+<style>
+  .quick-add {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 0.5rem;
+    border-radius: 1rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    transition: border-color 120ms, box-shadow 120ms, transform 120ms;
+  }
+  .quick-add:hover {
+    border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border));
+    box-shadow: 0 4px 14px rgba(0,0,0,0.08);
+  }
+  .quick-add-chip {
+    position: relative;
+    width: 2.6rem;
+    height: 2.6rem;
+    border-radius: 0.9rem;
+    display: grid;
+    place-items: center;
+    color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  }
+  /* The "+" badge makes it read as an add action, not navigation. */
+  .quick-add-plus {
+    position: absolute;
+    right: -0.28rem;
+    bottom: -0.28rem;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    color: #fff;
+    background: var(--color-accent);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.3), 0 0 0 2px var(--color-surface);
+  }
+  .quick-add-label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+</style>


### PR DESCRIPTION
Child PR (stacks onto the parent). Closes #68.

- **Touch reactivity**: varied active feedback under `(pointer: coarse)` — buttons/links scale, filled buttons dip in brightness, surfaces press in more gently — all neutralized under `[data-reduce-motion]`.
- **Cozier Home**: greeting is now a warm **"hearth"** card (time-of-day icon, dateline, greeting). Quick-add buttons are **action tiles** (accent icon chip + "+" badge, "New note / New place / Add media") so they read as actions, not nav.

Verified: check 0/0, build ok, 276 tests. Merges into the parent branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_