### PR TITLE
[G] Review round 1: map-in-detail, notes linking, videos/library/settings fixes

### DIFF
--- a/src/lib/components/PlaceDetailModal.svelte
+++ b/src/lib/components/PlaceDetailModal.svelte
@@ -11,6 +11,8 @@
   import { Timestamp } from 'firebase/firestore'
   import { Calendar, Check, ExternalLink, MapPin, Repeat, X } from 'lucide-svelte'
   import { cycleRating, getStarFill } from '$lib/utils'
+  import 'leaflet/dist/leaflet.css'
+  import type { Map as LeafletMap } from 'leaflet'
 
   interface Props {
     place: Place | null
@@ -32,6 +34,48 @@
       editedCategory = place.category
       editedBudget = place.budget ?? null
       previousPlaceId = place.id
+    }
+  })
+
+  // ===== Embedded, non-pannable location preview map =====
+  let mapEl = $state<HTMLDivElement | null>(null)
+  let miniMap: LeafletMap | undefined
+
+  $effect(() => {
+    const loc = place?.location
+    const el = mapEl
+    if (!loc || !el) return
+    const def = categoryDef(place!.category)
+    let disposed = false
+    ;(async () => {
+      const leaflet = await import('leaflet')
+      if (disposed || !mapEl) return
+      const L = leaflet.default ?? leaflet
+      // Display-only: no dragging, but pinch/scroll/buttons can still zoom.
+      miniMap = L.map(el, {
+        dragging: false,
+        scrollWheelZoom: false,
+        touchZoom: true,
+        doubleClickZoom: true,
+        boxZoom: false,
+        keyboard: false,
+        zoomControl: true,
+        attributionControl: false,
+      }).setView([loc.lat, loc.lng], 15)
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(miniMap)
+      const icon = L.divIcon({
+        html: `<div class="mini-pin" style="--pin:${def.color}"><span>${def.emoji}</span></div>`,
+        className: 'mini-pin-wrap',
+        iconSize: [30, 30],
+        iconAnchor: [15, 30],
+      })
+      L.marker([loc.lat, loc.lng], { icon }).addTo(miniMap)
+      requestAnimationFrame(() => miniMap?.invalidateSize())
+    })()
+    return () => {
+      disposed = true
+      miniMap?.remove()
+      miniMap = undefined
     }
   })
 
@@ -514,7 +558,7 @@
           </div>
         </div>
 
-        <!-- Location picker -->
+        <!-- Location picker + embedded preview map -->
         <div>
           <span class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Location</span>
           <LocationPicker
@@ -522,6 +566,11 @@
             onChange={updateLocation}
             placeholder="Search for address..."
           />
+          {#if place.location}
+            <div class="mini-map-frame mt-2">
+              <div class="mini-map-canvas" bind:this={mapEl}></div>
+            </div>
+          {/if}
         </div>
 
         <!-- Notes -->
@@ -602,3 +651,33 @@
     </div>
   </Modal>
 {/if}
+
+<style>
+  .mini-map-frame {
+    position: relative;
+    isolation: isolate;
+    height: 180px;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    border: 1px solid var(--color-border);
+  }
+  .mini-map-canvas { position: absolute; inset: 0; background: #ece3d2; }
+  /* Same aged-cartography wash as the main Places map, lighter touch. */
+  .mini-map-frame :global(.leaflet-tile-pane) {
+    filter: grayscale(0.5) sepia(0.35) saturate(0.85) contrast(1.03) brightness(1.03);
+  }
+  :global(.dark) .mini-map-frame :global(.leaflet-tile-pane) {
+    filter: grayscale(0.6) sepia(0.25) saturate(0.7) contrast(0.95) brightness(0.72) invert(0.9) hue-rotate(180deg);
+  }
+  .mini-map-frame :global(.mini-pin-wrap) { background: transparent; border: none; }
+  .mini-map-frame :global(.mini-pin) {
+    width: 30px; height: 30px;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--pin);
+    border: 2px solid #fff;
+    border-radius: 50% 50% 50% 0;
+    transform: rotate(-45deg);
+    box-shadow: 0 3px 6px rgba(0,0,0,0.35);
+  }
+  .mini-map-frame :global(.mini-pin span) { transform: rotate(45deg); font-size: 13px; line-height: 1; }
+</style>

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -41,6 +41,9 @@
   let unsubscribe: (() => void) | undefined
   let selectedMedia = $state<Media | null>(null)
 
+  // Local search over the existing library (distinct from the discovery search)
+  let librarySearch = $state('')
+
   // Search state (for adding new items)
   let searchQuery = $state('')
   let discoverResults = $state<TMDBSearchResult[]>([])
@@ -109,6 +112,7 @@
     filters = { ...DEFAULT_FILTERS, type }
     showAddPanel = false
     searchQuery = ''
+    librarySearch = ''
     discoverResults = []
     gameResults = []
   })
@@ -337,6 +341,14 @@
 
   let filteredMedia = $derived.by(() => {
     let result = applyFilters(typeMedia, { ...filters, type: 'all' }) // Type already filtered
+    const q = librarySearch.trim().toLowerCase()
+    if (q) {
+      result = result.filter(m =>
+        m.title.toLowerCase().includes(q) ||
+        (m.overview?.toLowerCase().includes(q) ?? false) ||
+        (m.genres?.some(g => g.toLowerCase().includes(q)) ?? false)
+      )
+    }
     result = applySort(result, sort)
     return result
   })
@@ -520,6 +532,27 @@
     </div>
   </div>
 
+  <!-- Search within the current library -->
+  <div class="relative mb-4">
+    <Search size={18} class="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+    <input
+      type="search"
+      placeholder="Search your {typeInfo[type].plural.toLowerCase()}…"
+      class="input pl-11"
+      bind:value={librarySearch}
+    />
+    {#if librarySearch}
+      <button
+        type="button"
+        class="absolute right-3 top-1/2 -translate-y-1/2 w-7 h-7 flex items-center justify-center text-slate-400 hover:text-slate-600 touch-manipulation"
+        onclick={() => librarySearch = ''}
+        aria-label="Clear search"
+      >
+        <X size={16} />
+      </button>
+    {/if}
+  </div>
+
   <!-- Add panel -->
   {#if showAddPanel}
     <div class="card p-4 mb-6" style="transform: translateZ(0);">
@@ -692,12 +725,13 @@
   <!-- Grid -->
   <div bind:this={gridContainer}>
     {#if filteredMedia.length === 0}
+      {@const isFiltered = activeFilterCount > 0 || !!librarySearch.trim()}
       <EmptyState
         icon={typeInfo[type].icon}
-        title={activeFilterCount > 0 ? `No ${typeInfo[type].plural.toLowerCase()} match your filters` : `No ${typeInfo[type].plural.toLowerCase()} in your library`}
-        description={activeFilterCount > 0 ? 'Try adjusting your filters' : `Add your first ${typeInfo[type].label.toLowerCase()}`}
-        actionLabel={activeFilterCount > 0 ? undefined : `Add ${typeInfo[type].label}`}
-        onAction={activeFilterCount > 0 ? undefined : toggleAddPanel}
+        title={isFiltered ? `No ${typeInfo[type].plural.toLowerCase()} match` : `No ${typeInfo[type].plural.toLowerCase()} in your library`}
+        description={isFiltered ? 'Try adjusting your search or filters' : `Add your first ${typeInfo[type].label.toLowerCase()}`}
+        actionLabel={isFiltered ? undefined : `Add ${typeInfo[type].label}`}
+        onAction={isFiltered ? undefined : toggleAddPanel}
       />
     {:else}
       <!-- svelte-ignore a11y_no_noninteractive_tabindex a11y_no_noninteractive_element_interactions -->

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -12,7 +12,7 @@
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { Note, NoteColor, UserId } from '$lib/types'
   import { Timestamp, type Timestamp as TimestampType } from 'firebase/firestore'
-  import { Archive, ArchiveRestore, Check, CheckCheck, Image as ImageIcon, Pencil, Pin, Reply, Search, SlidersHorizontal, ArrowUpDown, StickyNote, Trash2, X } from 'lucide-svelte'
+  import { Archive, ArchiveRestore, Check, CheckCheck, Image as ImageIcon, Pencil, Pin, Reply, Search, SlidersHorizontal, ArrowUpDown, StickyNote, Trash2, X, Link2, Unlink } from 'lucide-svelte'
   import { onMount } from 'svelte'
   import { toast } from 'svelte-sonner'
 
@@ -300,6 +300,45 @@
     }
   }
 
+  // ===== Linking / unlinking notes into threads =====
+  // Link the selected notes (and every note already sharing their threads) into
+  // one thread rooted at the earliest note.
+  async function bulkLink(): Promise<void> {
+    const faceIds = [...selectedIds]
+    if (faceIds.length < 2) return
+    const keys = new Set<string>()
+    for (const id of faceIds) {
+      const n = notes.find(x => x.id === id)
+      if (n) keys.add(threadKeyOf(n))
+    }
+    if (keys.size < 2) { toast('Those notes are already linked'); return }
+    const members = notes.filter(n => !n.archived && keys.has(threadKeyOf(n)))
+    const root = [...members].sort((a, b) => (a.createdAt?.toMillis?.() ?? 0) - (b.createdAt?.toMillis?.() ?? 0))[0]
+    const rootKey = root.threadId ?? root.id ?? ''
+    if (!rootKey) return
+    hapticSuccess()
+    for (const m of members) {
+      if (m.id === rootKey) continue
+      await updateDocument<Note>('notes', m.id!, { threadId: rootKey, replyTo: root.id! }, $activeUser)
+    }
+    toast.success(`Linked ${members.length} notes into a thread`)
+    selectedIds = new Set(); selectMode = false
+  }
+
+  // Detach a single note from its thread; it becomes its own standalone note.
+  async function unlinkNote(note: Note): Promise<void> {
+    if (!note.id) return
+    hapticMedium()
+    await updateDocument<Note>('notes', note.id, { threadId: note.id, replyTo: '' }, $activeUser)
+    toast.success('Note unlinked')
+  }
+
+  // Whether a note can be detached from the currently-open thread (not the root).
+  function canUnlink(note: Note): boolean {
+    const root = threadNotes[0]
+    return !!root && note.id !== root.id && threadNotes.length > 1
+  }
+
   // ===== Board view (new/all) persisted per session =====
   $effect(() => {
     try { sessionStorage.setItem('notes-board-view', boardView) } catch { /* private mode */ }
@@ -463,17 +502,28 @@
     { value: 'T', label: 'T' },
   ]
 
-  // Optional manual override of the board background colour.
+  // Optional manual override of the board background colour. When set, it tints
+  // the backdrop AND the control surfaces (rail + filter tray) so the whole
+  // board reads as one coloured object.
   let corkStyle = $derived.by(() => {
     const c = $currentPreferences?.corkboardColor?.trim()
-    return c ? `--cork-a:${c};--cork-b:${c};--cork-c:${c}` : ''
+    if (!c) return ''
+    return [
+      `--cork-a:${c}`,
+      `--cork-b:color-mix(in srgb, ${c} 88%, #000)`,
+      `--cork-c:color-mix(in srgb, ${c} 74%, #000)`,
+      // Darker framed wood-substitute for the control rail.
+      `--cork-rail:linear-gradient(180deg, color-mix(in srgb, ${c} 68%, #241a0e) 0%, color-mix(in srgb, ${c} 52%, #1c140a) 100%)`,
+      // Softly tinted tray that still keeps inputs legible.
+      `--cork-tray:color-mix(in srgb, ${c} 30%, var(--color-surface))`,
+    ].join(';')
   })
 </script>
 
 <!-- Full-bleed cork backdrop (fixed behind the page content) -->
 <div class="cork-backdrop" style={corkStyle} aria-hidden="true"></div>
 
-<div class="corkboard-page">
+<div class="corkboard-page" style={corkStyle}>
   <!-- Wooden control rail — the board's "tack & pen bin" -->
   <div class="cork-rail">
     <div class="flex items-center gap-2.5 min-w-0">
@@ -1038,6 +1088,7 @@
   <div class="bulk-bar">
     <span class="bulk-count">{selectedIds.size} selected</span>
     <div class="flex items-center gap-1.5">
+      <button type="button" class="bulk-btn" onclick={bulkLink} disabled={selectedIds.size < 2} title="Link into a thread"><Link2 size={16} /><span class="hidden sm:inline">Link</span></button>
       <button type="button" class="bulk-btn" onclick={bulkMarkRead}><Check size={16} /><span class="hidden sm:inline">Read</span></button>
       <button type="button" class="bulk-btn" onclick={bulkArchive}><Archive size={16} /><span class="hidden sm:inline">Archive</span></button>
       <button type="button" class="bulk-btn bulk-danger" onclick={bulkDelete}><Trash2 size={16} /><span class="hidden sm:inline">Delete</span></button>
@@ -1054,7 +1105,14 @@
         <div class="thread-note" style={noteVars(tone, n.customColor)}>
           <div class="flex items-center justify-between mb-1">
             <span class="thread-author">{n.createdBy === $activeUser ? 'You' : getDisplayNameForUser(n.createdBy)}</span>
-            <span class="thread-time">{getRelativeTime(n.createdAt)}</span>
+            <div class="flex items-center gap-1.5">
+              <span class="thread-time">{getRelativeTime(n.createdAt)}</span>
+              {#if canUnlink(n)}
+                <button type="button" class="thread-unlink" onclick={() => unlinkNote(n)} aria-label="Unlink from thread" title="Unlink from thread">
+                  <Unlink size={13} />
+                </button>
+              {/if}
+            </div>
           </div>
           {#if n.title}<h4 class="font-bold text-sm mb-0.5" style="color:var(--note-ink)">{n.title}</h4>{/if}
           {#if n.content}<p class="text-sm whitespace-pre-wrap" style="color:var(--note-ink);opacity:0.85">{n.content}</p>{/if}
@@ -1112,16 +1170,22 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     gap: 0.5rem;
+    row-gap: 0.5rem;
     padding: 0.6rem 0.85rem;
     border-radius: 0.9rem;
-    background: linear-gradient(180deg, #9a7b4f 0%, #86683f 100%);
+    background: var(--cork-rail, linear-gradient(180deg, #9a7b4f 0%, #86683f 100%));
     box-shadow:
       inset 0 1px 0 rgba(255,255,255,0.18),
       inset 0 -2px 4px rgba(0,0,0,0.25),
       0 3px 8px rgba(0,0,0,0.25);
     margin-bottom: 0.85rem;
   }
+  /* Title keeps a minimum footprint so the controls wrap to their own row on
+     narrow screens instead of overlapping "Our Board". */
+  .cork-rail > :first-child { flex: 1 1 auto; min-width: 8rem; }
+  .cork-rail > :last-child { flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; }
 
   .corkboard-pin-icon {
     width: 2rem;
@@ -1201,12 +1265,12 @@
     padding: 0.6rem 0.7rem;
     margin-bottom: 0.85rem;
     border-radius: 0.85rem;
-    background: rgba(255,255,255,0.82);
+    background: var(--cork-tray, rgba(255,255,255,0.82));
     backdrop-filter: blur(4px);
     box-shadow: 0 2px 8px rgba(0,0,0,0.12);
   }
   :global(.dark) .filter-tray {
-    background: rgba(30,26,22,0.8);
+    background: var(--cork-tray, rgba(30,26,22,0.8));
   }
 
   .tray-input {
@@ -1777,6 +1841,7 @@
     font-weight: 700;
     background: var(--color-surface-2);
   }
+  .bulk-btn:disabled { opacity: 0.4; pointer-events: none; }
   .bulk-danger { color: #ef4444; }
 
   /* ===== Thread modal notes ===== */
@@ -1788,4 +1853,11 @@
   }
   .thread-author { font-size: 0.65rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.04em; color: var(--note-ink); opacity: 0.6; }
   .thread-time { font-size: 0.65rem; color: var(--note-ink); opacity: 0.5; }
+  .thread-unlink {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 1.5rem; height: 1.5rem; border-radius: 50%;
+    color: var(--note-ink); opacity: 0.5;
+    transition: opacity 120ms, background 120ms;
+  }
+  .thread-unlink:hover { opacity: 0.9; background: rgba(0,0,0,0.08); }
 </style>

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -665,6 +665,10 @@
   /* ===== Map frame + hand-drawn skin ===== */
   .map-frame {
     position: relative;
+    /* Contain Leaflet's internal z-indexes (panes 400, controls 1000) so they
+       can't paint over app modals/overlays that sit above the page. */
+    isolation: isolate;
+    z-index: 0;
     height: 46vh;
     min-height: 300px;
     max-height: 460px;

--- a/src/lib/pages/Settings.svelte
+++ b/src/lib/pages/Settings.svelte
@@ -321,6 +321,24 @@
     savePreferences()
   }
 
+  // Warm, palette-compatible board colours that read well with the sticky-note
+  // tones (default cork tan first).
+  const CORKBOARD_PRESETS: Array<{ hex: string; label: string }> = [
+    { hex: '#c8a882', label: 'Cork tan' },
+    { hex: '#b08968', label: 'Chestnut' },
+    { hex: '#a3b18a', label: 'Sage' },
+    { hex: '#8fadc4', label: 'Dusty blue' },
+    { hex: '#c9a0b4', label: 'Mauve' },
+    { hex: '#d0a15c', label: 'Honey' },
+    { hex: '#9aa3ad', label: 'Slate' },
+    { hex: '#c58a6b', label: 'Terracotta' },
+  ]
+
+  function selectCorkboardPreset(hex: string): void {
+    hapticLight()
+    localCorkboardColor = hex
+    savePreferences()
+  }
   function handleCorkboardColorChange(): void {
     savePreferences()
   }
@@ -1146,23 +1164,42 @@
       </button>
 
       <!-- Notes board background override -->
-      <div class="flex items-center justify-between gap-3">
-        <span class="text-left">
-          <span class="block text-sm font-medium">Notes board background</span>
-          <span class="block text-xs text-slate-400">Override the corkboard color</span>
-        </span>
-        <div class="flex items-center gap-2 shrink-0">
-          <input
-            type="color"
-            class="w-9 h-9 rounded cursor-pointer border-0"
-            value={localCorkboardColor || '#c8a882'}
-            oninput={(e) => localCorkboardColor = (e.currentTarget as HTMLInputElement).value}
-            onchange={handleCorkboardColorChange}
-            aria-label="Board background color"
-          />
-          {#if localCorkboardColor}
-            <button type="button" class="btn-icon-sm touch-sm" onclick={clearCorkboardColor} aria-label="Reset board background">✕</button>
-          {/if}
+      <div>
+        <div class="flex items-center justify-between gap-3 mb-2">
+          <span class="text-left">
+            <span class="block text-sm font-medium">Notes board background</span>
+            <span class="block text-xs text-slate-400">Tints the board and its controls</span>
+          </span>
+          <div class="flex items-center gap-2 shrink-0">
+            <label class="relative w-9 h-9 rounded-lg cursor-pointer border border-[var(--color-border)] overflow-hidden" title="Custom color" aria-label="Custom board color">
+              <span class="absolute inset-0" style="background:{localCorkboardColor || '#c8a882'}"></span>
+              <input
+                type="color"
+                class="sr-only"
+                value={localCorkboardColor || '#c8a882'}
+                oninput={(e) => localCorkboardColor = (e.currentTarget as HTMLInputElement).value}
+                onchange={handleCorkboardColorChange}
+                aria-label="Board background color"
+              />
+            </label>
+            {#if localCorkboardColor}
+              <button type="button" class="btn-icon-sm touch-sm" onclick={clearCorkboardColor} aria-label="Reset board background">✕</button>
+            {/if}
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          {#each CORKBOARD_PRESETS as preset}
+            <button
+              type="button"
+              class="w-8 h-8 rounded-lg flex items-center justify-center text-white shadow-sm touch-sm transition-transform hover:scale-105 {localCorkboardColor.toLowerCase() === preset.hex ? 'ring-2 ring-accent ring-offset-1 ring-offset-[var(--color-surface)]' : ''}"
+              style="background:{preset.hex}"
+              onclick={() => selectCorkboardPreset(preset.hex)}
+              aria-label={preset.label}
+              title={preset.label}
+            >
+              {#if localCorkboardColor.toLowerCase() === preset.hex}<CheckIcon size={14} />{/if}
+            </button>
+          {/each}
         </div>
       </div>
     </section>

--- a/src/lib/pages/Videos.svelte
+++ b/src/lib/pages/Videos.svelte
@@ -273,14 +273,14 @@
 
 </script>
 
-<div class="min-h-screen bg-slate-50 dark:bg-slate-900">
+<div class="max-w-5xl mx-auto">
   <!-- Header -->
-  <div class="bg-white dark:bg-slate-800 border-b border-[var(--color-border)] sticky top-0 z-10">
-    <div class="max-w-7xl mx-auto px-4 py-4">
+  <div class="mb-4">
+    <div>
       <div class="flex items-center justify-between mb-4">
         <div class="flex items-center gap-3">
           <VideoIcon size={28} class="text-accent" />
-          <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">Video Queue</h1>
+          <h1 class="text-2xl font-bold">Video Queue</h1>
         </div>
         <div class="flex items-center gap-2">
           <!-- Sync button -->
@@ -380,7 +380,7 @@
   </div>
 
   <!-- Content -->
-  <div class="max-w-7xl mx-auto px-4 py-6">
+  <div class="py-2">
     {#if loading}
       <div class="text-center py-12">
         <div class="inline-block w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin"></div>


### PR DESCRIPTION
Child PR **G** in the redesign-polish stack — addresses the first round of preview review comments.

| # | Comment | Fix |
|---|---------|-----|
| 1 | Selecting a place pops details, but the map overlays on top | `isolation: isolate` on `.map-frame` contains Leaflet's z-index (controls are z-1000) so it stays under modals. Plus, as you suggested, the detail panel now embeds its **own** non-pannable location map (dragging off, zoom on) — simpler and avoids the overlay entirely. |
| 2 | Notes New/All selector covers "Our Board" on mobile | The control rail now wraps; the title keeps a min footprint so controls drop to their own row instead of overlapping. |
| 3 | Linking/unlinking notes should be possible | **Link** action in the multi-select bulk bar merges selected notes into one thread (rooted at the earliest); per-note **unlink** in the thread view detaches a note back to standalone. (Went with select-mode + thread-view over drag-and-drop for touch reliability — happy to add DnD if you want it too.) |
| 4 | Library search has no access method | Restored a search bar on the library page that filters existing items by title / overview / genre. (The discovery search stays in the Add panel.) |
| 5 | Videos page renders black bars on all sides | Dropped the full-bleed `min-h-screen bg-slate-900` wrapper + sticky self-header that fought the shared app shell; uses the standard page layout now. |
| 6 | Corkboard bg color should affect controls + palette-compatible options | The override now also tints the control rail and filter tray; Settings adds a row of curated preset swatches (Cork tan, Sage, Dusty blue, Mauve, …) next to the custom picker. |

## Verification
- `bun run check` — 0 errors / 0 warnings
- `bun run build` — succeeds
- `bun run test:run` — 276/276 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_