### PR TITLE
[I] Notes: fill/normalize the board flow; keep signatures legible on any paper

### DIFF
--- a/src/lib/color.test.ts
+++ b/src/lib/color.test.ts
@@ -8,6 +8,8 @@ import {
     shiftHue,
     hueDistance,
     relativeLuminance,
+    contrastRatio,
+    ensureReadable,
 } from "./color"
 
 describe("color utilities", () => {
@@ -85,6 +87,38 @@ describe("color utilities", () => {
             expect(hueDistance(350, 10)).toBe(20)
             expect(hueDistance(0, 180)).toBe(180)
             expect(hueDistance(90, 90)).toBe(0)
+        })
+    })
+
+    describe("contrastRatio", () => {
+        it("is maximal for black on white", () => {
+            expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 0)
+        })
+        it("is 1 for identical colors", () => {
+            expect(contrastRatio("#e11d48", "#e11d48")).toBeCloseTo(1, 5)
+        })
+        it("is symmetric", () => {
+            expect(contrastRatio("#123456", "#abcdef")).toBeCloseTo(
+                contrastRatio("#abcdef", "#123456"), 5
+            )
+        })
+    })
+
+    describe("ensureReadable", () => {
+        it("returns the color unchanged when it already contrasts", () => {
+            expect(ensureReadable("#1c1917", "#fef08a", 3)).toBe("#1c1917")
+        })
+        it("recolors a same-as-background signature to be legible", () => {
+            // tack === bg (the custom-color collision case)
+            const out = ensureReadable("#e11d48", "#e11d48", 3.2)
+            expect(out).not.toBe("#e11d48")
+            expect(contrastRatio(out, "#e11d48")).toBeGreaterThanOrEqual(3.2)
+        })
+        it("preserves hue while adjusting lightness", () => {
+            const out = ensureReadable("#e11d48", "#e11d48", 3.2)
+            const target = hexToHsl("#e11d48")
+            const got = hexToHsl(out)
+            expect(hueDistance(got.h, target.h)).toBeLessThanOrEqual(4)
         })
     })
 })

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -101,6 +101,35 @@ export function readableInk(bgHex: string, darkInk = "#1c1917", lightInk = "#faf
     return relativeLuminance(bgHex) > 0.45 ? darkInk : lightInk
 }
 
+/** WCAG contrast ratio between two colors (1..21). */
+export function contrastRatio(a: string, b: string): number {
+    const la = relativeLuminance(a)
+    const lb = relativeLuminance(b)
+    const hi = Math.max(la, lb)
+    const lo = Math.min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+}
+
+/**
+ * Nudge `color`'s lightness away from `bg` until it clears a minimum contrast
+ * ratio, preserving hue and saturation so the result still reads as the same
+ * colour. Falls back to readable ink if hue-preserving adjustment can't get
+ * there. Used to keep note signatures legible against any paper colour.
+ */
+export function ensureReadable(color: string, bg: string, min = 3): string {
+    if (contrastRatio(color, bg) >= min) return color
+    const { h, s } = hexToHsl(color)
+    const darken = relativeLuminance(bg) > 0.4
+    let l = hexToHsl(color).l
+    for (let i = 0; i < 24; i++) {
+        l = darken ? l - 4 : l + 4
+        if (l <= 0 || l >= 100) break
+        const candidate = hslToHex({ h, s, l })
+        if (contrastRatio(candidate, bg) >= min) return candidate
+    }
+    return readableInk(bg)
+}
+
 export function shiftHue(hex: string, degrees: number): string {
     const hsl = hexToHsl(hex)
     return hslToHex({ ...hsl, h: hsl.h + degrees })

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -8,7 +8,7 @@
   import { activeUser, currentPreferences, displayNames, userPreferences } from '$lib/stores/app'
   import { consumeQueryParam } from '$lib/stores/nav'
   import { getNotePalette, resolveNoteTone, resolveToneShift, NOTE_TONE_KEYS, type NoteTone } from '$lib/notePalette'
-  import { readableInk } from '$lib/color'
+  import { readableInk, ensureReadable } from '$lib/color'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { Note, NoteColor, UserId } from '$lib/types'
   import { Timestamp, type Timestamp as TimestampType } from 'firebase/firestore'
@@ -84,7 +84,11 @@
     const bg = custom || (isDark ? tone.bgDark : tone.bgLight)
     const ink = custom ? readableInk(custom) : (isDark ? tone.inkDark : tone.inkLight)
     const tack = custom || tone.tack
-    return `--note-bg:${bg};--note-ink:${ink};--note-tack:${tack};`
+    // The signature is drawn in the tack colour, but a custom paper colour (or a
+    // tone whose tack sits close to the paper) can make it illegible — so recolor
+    // it to guarantee contrast against this note's background.
+    const sign = ensureReadable(tack, bg, 3.2)
+    return `--note-bg:${bg};--note-ink:${ink};--note-tack:${tack};--note-sign:${sign};`
   }
 
   // Full inline style for a board note: colour + tilt + horizontal/vertical
@@ -1370,20 +1374,22 @@
     background: rgba(0,0,0,0.2);
   }
 
-  /* Organic wrapping flow — notes are sized to their content (below), so the
-     ragged widths never line up into columns the way a fixed masonry does. */
+  /* Organic wrapping flow. Notes are sized to their content (flex-basis below)
+     for variety, but grow to fill the row so the board never bunches in the
+     middle or leaves large empty chunks. Ragged bases + jitter keep it from
+     reading as fixed columns. */
   .notes-masonry {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
-    justify-content: center;
     gap: 0.5rem 0.6rem;
   }
 
   /* ===== STICKY NOTE ===== */
   .sticky-note {
     position: relative;
-    width: 12rem; /* default (m); size variants below */
+    flex: 1 1 12rem; /* grow to fill the row; basis set per size below */
+    max-width: 16rem;
     border-radius: 2px;
     padding: 0.875rem 0.875rem 0.6rem;
     cursor: pointer;
@@ -1395,14 +1401,12 @@
     box-shadow: 2px 3px 10px rgba(0,0,0,0.18), 0 1px 2px rgba(0,0,0,0.1);
   }
 
-  /* Content-driven sizes: small clippings vs. fuller notes. */
-  .sticky-note.note-xs { width: 8rem; }
-  .sticky-note.note-s  { width: 10rem; }
-  .sticky-note.note-m  { width: 12rem; }
-  .sticky-note.note-l  { width: 14.5rem; }
-  @media (min-width: 640px) {
-    .sticky-note.note-l { width: 16rem; }
-  }
+  /* Content-driven bases + growth caps: small clippings stay tighter, fuller
+     notes are allowed to spread wider. */
+  .sticky-note.note-xs { flex-basis: 8rem;  max-width: 11rem; }
+  .sticky-note.note-s  { flex-basis: 10rem; max-width: 13rem; }
+  .sticky-note.note-m  { flex-basis: 12rem; max-width: 15rem; }
+  .sticky-note.note-l  { flex-basis: 14rem; max-width: 19rem; }
 
   .sticky-note:hover, .sticky-note:focus-visible {
     transform: translateX(var(--jx, 0)) rotate(0deg) scale(1.03);
@@ -1504,8 +1508,8 @@
     font-style: italic;
     font-size: 0.8rem;
     font-weight: 600;
-    color: var(--note-tack);
-    opacity: 0.85;
+    color: var(--note-sign, var(--note-tack));
+    opacity: 0.95;
     word-break: break-word;
   }
 


### PR DESCRIPTION
Child PR **I** — two follow-ups from the last preview.

**1. Anchoring / normalization (no bunching, fills the space)**
The centered wrap left ragged gaps and clustered notes. Notes now **grow to fill each row** (flex-grow) off content-driven flex-bases, with per-size growth caps so small clippings stay tight and fuller notes spread. Rows fill edge-to-edge instead of bunching in the middle or leaving large empty chunks; ragged bases + jitter + tilt still keep it from reading as fixed columns.

**2. Signature legibility on any paper**
Signatures were drawn in the tack color, which **collides with the paper** when a note uses a custom color (tack == background) or when a tone's tack sits too close to its paper. Added `contrastRatio` + `ensureReadable` to `color.ts`: the signature color is now nudged in lightness (hue/saturation preserved, ink fallback) until it clears a contrast threshold against that note's background. So it auto-recolors only when it would otherwise be illegible.

Added unit tests for both new color helpers.

## Verification
- `bun run check` — 0 / 0
- `bun run build` — ok
- `bun run test:run` — 282/282 (6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_