### PR TITLE
[K] Identity pill: keep the fly-out inside the viewport

### DIFF
--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -6,6 +6,7 @@
   import { hapticLight } from '$lib/haptics'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { UserId } from '$lib/types'
+  import { clampPosition, flyoutPlacement } from '$lib/identityPill'
 
   const STORAGE_KEY = 'identity-pill-pos'
   const DRAG_THRESHOLD = 6
@@ -16,6 +17,9 @@
   // Persisted top-left position (px). Null = default bottom-right anchor.
   let pos = $state<{ x: number; y: number } | null>(null)
   let dragging = $state(false)
+  // Which way the fly-out opens so it stays inside the viewport.
+  let openLeft = $state(true)
+  let openUp = $state(true)
 
   // Non-reactive drag internals
   let pointerId: number | null = null
@@ -34,7 +38,7 @@
     }
     // Clamp after layout so a resized viewport can't strand the pill offscreen.
     requestAnimationFrame(clampIntoView)
-    const onResize = () => clampIntoView()
+    const onResize = () => { clampIntoView(); if (isExpanded) computePlacement() }
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   })
@@ -42,12 +46,18 @@
   function clampIntoView(): void {
     if (!pos || !pillEl) return
     const rect = pillEl.getBoundingClientRect()
-    const maxX = Math.max(EDGE_MARGIN, window.innerWidth - rect.width - EDGE_MARGIN)
-    const maxY = Math.max(EDGE_MARGIN, window.innerHeight - rect.height - EDGE_MARGIN)
-    pos = {
-      x: Math.min(Math.max(EDGE_MARGIN, pos.x), maxX),
-      y: Math.min(Math.max(EDGE_MARGIN, pos.y), maxY),
-    }
+    pos = clampPosition(pos, { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight }, EDGE_MARGIN)
+  }
+
+  // Choose the fly-out direction from where the collapsed pill sits.
+  function computePlacement(): void {
+    if (!pillEl) return
+    const rect = pillEl.getBoundingClientRect()
+    const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+    const p = flyoutPlacement(center, { width: window.innerWidth, height: window.innerHeight })
+    openLeft = p.openLeft
+    openUp = p.openUp
   }
 
   function onPointerDown(e: PointerEvent): void {
@@ -74,12 +84,12 @@
     if (dragging) {
       e.preventDefault()
       const rect = pillEl.getBoundingClientRect()
-      const maxX = window.innerWidth - rect.width - EDGE_MARGIN
-      const maxY = window.innerHeight - rect.height - EDGE_MARGIN
-      pos = {
-        x: Math.min(Math.max(EDGE_MARGIN, e.clientX - grabDX), maxX),
-        y: Math.min(Math.max(EDGE_MARGIN, e.clientY - grabDY), maxY),
-      }
+      pos = clampPosition(
+        { x: e.clientX - grabDX, y: e.clientY - grabDY },
+        { width: rect.width, height: rect.height },
+        { width: window.innerWidth, height: window.innerHeight },
+        EDGE_MARGIN,
+      )
     }
   }
 
@@ -103,6 +113,7 @@
   function toggle(e: MouseEvent): void {
     e.stopPropagation()
     if (justDragged) return
+    if (!isExpanded) computePlacement()
     isExpanded = !isExpanded
   }
 
@@ -123,6 +134,11 @@
   }
 
   let otherUser = $derived<UserId>($activeUser === 'Z' ? 'T' : 'Z')
+
+  // Panel anchored to the pill, flipping toward on-screen space.
+  let panelStyle = $derived(
+    `${openLeft ? 'right:0;' : 'left:0;'}${openUp ? 'bottom:calc(100% + 10px);' : 'top:calc(100% + 10px);'}`
+  )
 
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Escape' && isExpanded) {
@@ -152,10 +168,24 @@
   onpointerup={onPointerUp}
   onpointercancel={onPointerUp}
 >
+  <!-- Collapsed trigger (tap to switch, hold and drag to move) — always the
+       anchor, so the panel can float around it without moving the pill. -->
+  <button
+    type="button"
+    aria-label="Switch user — hold and drag to move"
+    aria-expanded={isExpanded}
+    class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-lg transition-transform hover:scale-105 touch-manipulation"
+    style:background-color={$userPreferences[$activeUser]?.accentColor ?? DEFAULT_ACCENT}
+    onclick={toggle}
+  >
+    {$displayAbbreviations[$activeUser]}
+  </button>
+
   {#if isExpanded}
     <!-- Expanded panel: switch identity + profile access -->
     <div
-      class="flex flex-col gap-2 p-2 rounded-2xl bg-surface border border-[var(--color-border)] shadow-xl w-52"
+      class="pill-panel flex flex-col gap-2 p-2 rounded-2xl bg-surface border border-[var(--color-border)] shadow-xl w-52"
+      style={panelStyle}
       role="dialog"
       aria-label="Identity and profiles"
     >
@@ -198,17 +228,6 @@
         {$displayNames[otherUser]}'s keepsakes
       </button>
     </div>
-  {:else}
-    <!-- Collapsed trigger (tap to switch, hold and drag to move) -->
-    <button
-      type="button"
-      aria-label="Switch user — hold and drag to move"
-      class="w-11 h-11 rounded-full flex items-center justify-center text-white text-sm font-bold shadow-lg transition-transform hover:scale-105 touch-manipulation"
-      style:background-color={$userPreferences[$activeUser]?.accentColor ?? DEFAULT_ACCENT}
-      onclick={toggle}
-    >
-      {$displayAbbreviations[$activeUser]}
-    </button>
   {/if}
 </div>
 
@@ -216,4 +235,11 @@
   .pill-root :global(button) { cursor: grab; }
   .pill-root.is-dragging { cursor: grabbing; }
   .pill-root.is-dragging :global(button) { cursor: grabbing; }
+  /* Fly-out floats around the pill and never exceeds the safe viewport. */
+  .pill-panel {
+    position: absolute;
+    max-width: min(13rem, calc(100vw - 16px));
+    max-height: calc(100dvh - 16px);
+    overflow: auto;
+  }
 </style>

--- a/src/lib/identityPill.test.ts
+++ b/src/lib/identityPill.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { clampPosition, flyoutPlacement, centerOf } from "./identityPill"
+
+const VP = { width: 1000, height: 800 }
+
+describe("identityPill geometry", () => {
+    describe("clampPosition", () => {
+        const size = { width: 44, height: 44 }
+
+        it("leaves an in-bounds position untouched", () => {
+            expect(clampPosition({ x: 500, y: 400 }, size, VP, 8)).toEqual({ x: 500, y: 400 })
+        })
+
+        it("pulls a bottom-right overflow back inside with the margin", () => {
+            const out = clampPosition({ x: 5000, y: 5000 }, size, VP, 8)
+            expect(out).toEqual({ x: 1000 - 44 - 8, y: 800 - 44 - 8 })
+        })
+
+        it("respects the top-left margin", () => {
+            expect(clampPosition({ x: -100, y: -100 }, size, VP, 8)).toEqual({ x: 8, y: 8 })
+        })
+
+        it("clamps a wide panel (larger than viewport) to the margin", () => {
+            const panel = { width: 2000, height: 300 }
+            const out = clampPosition({ x: 900, y: 400 }, panel, VP, 8)
+            expect(out.x).toBe(8)
+        })
+    })
+
+    describe("flyoutPlacement", () => {
+        it("opens up-left from the bottom-right quadrant", () => {
+            expect(flyoutPlacement({ x: 900, y: 700 }, VP)).toEqual({ openLeft: true, openUp: true })
+        })
+        it("opens down-right from the top-left quadrant", () => {
+            expect(flyoutPlacement({ x: 100, y: 100 }, VP)).toEqual({ openLeft: false, openUp: false })
+        })
+        it("opens up-right from the bottom-left quadrant", () => {
+            expect(flyoutPlacement({ x: 100, y: 700 }, VP)).toEqual({ openLeft: false, openUp: true })
+        })
+    })
+
+    describe("centerOf", () => {
+        it("computes the box center", () => {
+            expect(centerOf({ x: 10, y: 20 }, { width: 44, height: 44 })).toEqual({ x: 32, y: 42 })
+        })
+    })
+})

--- a/src/lib/identityPill.ts
+++ b/src/lib/identityPill.ts
@@ -1,0 +1,37 @@
+// Pure geometry helpers for the floating identity pill and its fly-out panel.
+// Kept dependency-free so they can be unit-tested without a DOM.
+
+export interface Point { x: number; y: number }
+export interface Size { width: number; height: number }
+export interface Viewport { width: number; height: number }
+
+/**
+ * Clamp a top-left position so a box of `size` stays fully within `vp`, keeping
+ * at least `margin` px from every edge. When the box is larger than the space,
+ * it pins to the top/left margin rather than going negative.
+ */
+export function clampPosition(pos: Point, size: Size, vp: Viewport, margin: number): Point {
+  const maxX = Math.max(margin, vp.width - size.width - margin)
+  const maxY = Math.max(margin, vp.height - size.height - margin)
+  return {
+    x: Math.min(Math.max(margin, pos.x), maxX),
+    y: Math.min(Math.max(margin, pos.y), maxY),
+  }
+}
+
+/**
+ * Decide which way the fly-out panel should open so it stays on screen: it
+ * opens toward the larger free space, i.e. leftward/upward when the pill sits
+ * past the viewport midpoint on that axis.
+ */
+export function flyoutPlacement(pillCenter: Point, vp: Viewport): { openLeft: boolean; openUp: boolean } {
+  return {
+    openLeft: pillCenter.x > vp.width / 2,
+    openUp: pillCenter.y > vp.height / 2,
+  }
+}
+
+/** Center point of a box given its top-left position and size. */
+export function centerOf(pos: Point, size: Size): Point {
+  return { x: pos.x + size.width / 2, y: pos.y + size.height / 2 }
+}


### PR DESCRIPTION
Child PR **K** — fixes the identity/profile fly-out escaping the viewport.

**Cause:** the pill anchored the expanded panel by its top-left corner, so once you dragged the pill toward the bottom-right, the ~208px panel extended off the right/bottom edge. The collapse re-clamp measured the *expanded* panel rather than the small pill, which is what yanked the whole thing toward the middle on close.

**Fix:**
- The collapsed pill button is now a **persistent anchor**; the panel floats as an absolutely-positioned popover that **flips toward on-screen space** — it opens left/up when the pill sits past the viewport midpoint, down/right otherwise.
- Because the panel is out of flow, the pill's stored position stays a stable 44px box, so clamp-on-resize can't drift it.
- Panel is constrained to the safe viewport (`max-width`/`max-height`, `dvh` units).

**Testing habit:** per your note, I pulled the geometry into a pure `identityPill.ts` module (`clampPosition` / `flyoutPlacement` / `centerOf`) and added `identityPill.test.ts` covering the overflow, margin, oversized-panel, and quadrant-flip cases. I'll keep writing tests alongside new logic going forward, and backfill coverage on earlier work where it's worthwhile.

## Verification
- `bun run check` — 0 / 0
- `bun run build` — ok
- `bun run test:run` — 290 / 290 (8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_