### PR TITLE
[N] Media: "Between Us" couple watch-state lens

### DIFF
--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -49,6 +49,10 @@ interface Media extends BaseDocument {
   rating: number | null              // Legacy single rating (1-5)
   ratings?: Record<UserId, number | null>  // Per-user ratings
 
+  // Couple watch-state: which partners have personally watched this. A per-user
+  // rating also counts as watched (see hasWatched/watchTogetherness in types.ts).
+  seenBy?: UserId[]
+
   // User content
   notes: string
   progress?: MediaProgress

--- a/src/lib/components/MediaDetailModal.svelte
+++ b/src/lib/components/MediaDetailModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { tmdbConfig } from '$lib/config'
   import { updateDocument } from '$lib/firebase'
-  import { activeUser, displayNames } from '$lib/stores/app'
+  import { activeUser, displayNames, displayAbbreviations, userPreferences } from '$lib/stores/app'
   import type { Media, MediaComment, MediaStatus, UserId } from '$lib/types'
-  import { getUserRating, getAverageRating } from '$lib/types'
+  import { getUserRating, getAverageRating, hasWatched, toggleSeenBy } from '$lib/types'
+  import { DEFAULT_ACCENT } from '$lib/accents'
   import { Timestamp } from 'firebase/firestore'
   import { Film, Tv, Gamepad2 } from 'lucide-svelte'
   import { hapticLight } from '$lib/haptics'
@@ -92,6 +93,14 @@
     if (!media?.id) return;
     hapticLight();
     await updateDocument<Media>('media', media.id, { status }, $activeUser);
+  }
+
+  const coupleUsers: UserId[] = ['Z', 'T']
+
+  async function toggleSeen(userId: UserId): Promise<void> {
+    if (!media?.id) return
+    hapticLight()
+    await updateDocument<Media>('media', media.id, { seenBy: toggleSeenBy(media, userId) }, $activeUser)
   }
 
   async function updateRating(userId: UserId, starIndex: number): Promise<void> {
@@ -218,6 +227,28 @@
             </select>
           </div>
           
+          <div class="flex-1 min-w-[160px]">
+            <span class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Watched by</span>
+            <div class="flex flex-col gap-1.5">
+              {#each coupleUsers as u}
+                {@const seen = hasWatched(media, u)}
+                <button
+                  type="button"
+                  class="flex items-center gap-2 px-2 py-1.5 rounded-xl text-sm font-medium transition-colors touch-manipulation border {seen ? 'border-transparent text-white' : 'border-[var(--color-border)] text-slate-500 dark:text-slate-400'}"
+                  style={seen ? `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}` : ''}
+                  onclick={() => toggleSeen(u)}
+                  aria-pressed={seen}
+                >
+                  <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 {seen ? 'bg-white/25' : ''}" style={seen ? '' : `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}20;color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}`}>
+                    {$displayAbbreviations[u]}
+                  </span>
+                  <span class="truncate">{getDisplayNameForUser(u)}</span>
+                  <span class="ml-auto text-xs opacity-80">{seen ? 'Watched' : 'Mark'}</span>
+                </button>
+              {/each}
+            </div>
+          </div>
+
           <div class="flex-1 min-w-[200px]">
             <span class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Ratings</span>
             

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { tmdbConfig } from '$lib/config'
   import { addDocument, deleteDocument, subscribeToCollection, updateDocument } from '$lib/firebase'
-  import { activeUser, displayNames, mediaGridSize, type GridSize } from '$lib/stores/app'
-  import type { Media, MediaStatus, MediaType, TMDBSearchResult, UserId, ProductionCompany, MediaCollection } from '$lib/types'
+  import { activeUser, displayNames, displayAbbreviations, userPreferences, mediaGridSize, type GridSize } from '$lib/stores/app'
+  import type { Media, MediaStatus, MediaType, TMDBSearchResult, UserId, ProductionCompany, MediaCollection, TogethernessState } from '$lib/types'
   import { toast } from 'svelte-sonner'
-  import { getDisplayRating } from '$lib/types'
+  import { getDisplayRating, hasWatched, watchTogetherness, toggleSeenBy } from '$lib/types'
+  import { DEFAULT_ACCENT } from '$lib/accents'
   import { enrichMediaData } from '$lib/tmdb'
   import { searchGames, type WikiGameResult } from '$lib/wikipedia'
   import {
@@ -24,7 +25,7 @@
   import IconButton from '$lib/components/ui/IconButton.svelte'
   import EmptyState from '$lib/components/ui/EmptyState.svelte'
   import ConfirmModal from '$lib/components/ui/ConfirmModal.svelte'
-    import { Film, Tv, Gamepad2, Filter, Plus, Search, X } from 'lucide-svelte'
+    import { Film, Tv, Gamepad2, Filter, Plus, Search, X, Check } from 'lucide-svelte'
   import { hapticSuccess } from '$lib/haptics'
   import { forceRepaint } from '$lib/pwa-utils'
   import { cycleRating, getStarFill } from '$lib/utils'
@@ -43,6 +44,11 @@
 
   // Local search over the existing library (distinct from the discovery search)
   let librarySearch = $state('')
+
+  // "Between Us" couple lens — filter by who of the pair has watched, from the
+  // active user's perspective.
+  let betweenUs = $state<TogethernessState | 'all'>('all')
+  let partner = $derived<UserId>($activeUser === 'Z' ? 'T' : 'Z')
 
   // Search state (for adding new items)
   let searchQuery = $state('')
@@ -88,6 +94,7 @@
 
   // Quick navigation between library types
   const libraryTypes: MediaType[] = ['movie', 'tv', 'game']
+  const coupleUsers: UserId[] = ['Z', 'T']
 
   onMount(() => {
     // Open the add/discover panel directly when arriving via a quick-add link.
@@ -349,9 +356,34 @@
         (m.genres?.some(g => g.toLowerCase().includes(q)) ?? false)
       )
     }
+    if (betweenUs !== 'all') {
+      result = result.filter(m => watchTogetherness(m, $activeUser, partner) === betweenUs)
+    }
     result = applySort(result, sort)
     return result
   })
+
+  // Counts per couple-state (over this type), for the lens chips.
+  let betweenUsCounts = $derived.by(() => {
+    const counts: Record<TogethernessState, number> = { both: 0, mine: 0, theirs: 0, none: 0 }
+    for (const m of typeMedia) counts[watchTogetherness(m, $activeUser, partner)]++
+    return counts
+  })
+
+  // The lens options, labelled from the viewer's POV.
+  let lensOptions = $derived<Array<{ key: TogethernessState | 'all'; label: string; count?: number }>>([
+    { key: 'all', label: 'All' },
+    { key: 'none', label: 'New to us', count: betweenUsCounts.none },
+    { key: 'theirs', label: 'Waiting on you', count: betweenUsCounts.theirs },
+    { key: 'mine', label: `Waiting on ${$displayNames[partner]}`, count: betweenUsCounts.mine },
+    { key: 'both', label: 'Seen together', count: betweenUsCounts.both },
+  ])
+
+  async function toggleSeen(item: Media, user: UserId): Promise<void> {
+    if (!item.id) return
+    hapticSuccess()
+    await updateDocument<Media>('media', item.id, { seenBy: toggleSeenBy(item, user) }, $activeUser)
+  }
 
   function posterUrl(path: string | null | undefined, size: 'sm' | 'md' = 'sm'): string | null {
     if (!path) return null
@@ -553,6 +585,20 @@
     {/if}
   </div>
 
+  <!-- "Between Us" couple lens -->
+  <div class="flex items-center gap-1.5 overflow-x-auto scrollbar-none mb-4 -mx-1 px-1">
+    {#each lensOptions as opt (opt.key)}
+      <button
+        type="button"
+        class="lens-chip {betweenUs === opt.key ? 'is-on' : ''}"
+        onclick={() => { betweenUs = betweenUs === opt.key ? 'all' : opt.key }}
+      >
+        <span>{opt.label}</span>
+        {#if opt.count !== undefined && opt.count > 0}<span class="lens-count">{opt.count}</span>{/if}
+      </button>
+    {/each}
+  </div>
+
   <!-- Add panel -->
   {#if showAddPanel}
     <div class="card p-4 mb-6" style="transform: translateZ(0);">
@@ -725,7 +771,7 @@
   <!-- Grid -->
   <div bind:this={gridContainer}>
     {#if filteredMedia.length === 0}
-      {@const isFiltered = activeFilterCount > 0 || !!librarySearch.trim()}
+      {@const isFiltered = activeFilterCount > 0 || !!librarySearch.trim() || betweenUs !== 'all'}
       <EmptyState
         icon={typeInfo[type].icon}
         title={isFiltered ? `No ${typeInfo[type].plural.toLowerCase()} match` : `No ${typeInfo[type].plural.toLowerCase()} in your library`}
@@ -820,6 +866,24 @@
                 {/each}
               </div>
 
+              <!-- Seen-by (couple watch-state): tap a face to toggle who's watched -->
+              <div class="flex items-center gap-1 mt-1.5">
+                {#each coupleUsers as u}
+                  {@const seen = hasWatched(item, u)}
+                  <button
+                    type="button"
+                    class="seen-dot {seen ? 'is-seen' : ''}"
+                    style={seen ? `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}` : ''}
+                    onclick={(e) => { e.stopPropagation(); toggleSeen(item, u) }}
+                    aria-pressed={seen}
+                    title="{$displayNames[u]} {seen ? 'has watched — tap to unmark' : 'hasn’t watched — tap to mark'}"
+                  >
+                    <span>{$displayAbbreviations[u]}</span>
+                    {#if seen}<span class="seen-check"><Check size={9} strokeWidth={3.5} /></span>{/if}
+                  </button>
+                {/each}
+              </div>
+
               <div class="flex gap-1.5 mt-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                 {#if item.status !== 'watching'}
                   <button
@@ -854,6 +918,72 @@
     .group:focus-within .group-hover\:opacity-100 {
       opacity: 1;
     }
+  }
+
+  /* ===== "Between Us" couple lens ===== */
+  .lens-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex: 0 0 auto;
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    white-space: nowrap;
+    color: var(--color-text-muted, #57534e);
+    background: var(--color-surface-2);
+    border: 1px solid transparent;
+    transition: background 120ms, color 120ms, border-color 120ms;
+  }
+  .lens-chip.is-on {
+    background: var(--color-accent);
+    color: #fff;
+  }
+  .lens-count {
+    font-size: 0.68rem;
+    font-weight: 800;
+    padding: 0.02rem 0.35rem;
+    border-radius: 999px;
+    background: rgba(0,0,0,0.12);
+  }
+  .lens-chip.is-on .lens-count { background: rgba(255,255,255,0.25); }
+
+  /* ===== Per-card seen-by faces ===== */
+  .seen-dot {
+    position: relative;
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-weight: 800;
+    color: var(--color-text-hint, #78716c);
+    background: transparent;
+    border: 1.5px dashed var(--color-border);
+    transition: transform 100ms;
+  }
+  .seen-dot.is-seen {
+    color: #fff;
+    border-style: solid;
+    border-color: transparent;
+  }
+  .seen-dot:active { transform: scale(0.9); }
+  .seen-check {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    width: 0.72rem;
+    height: 0.72rem;
+    border-radius: 50%;
+    background: #10b981;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 0 1.5px var(--color-surface);
   }
 
   /* ===== Cinema marquee header ===== */

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -20,8 +20,24 @@ import {
     getUserRating,
     formatBudget,
     getBudgetLabel,
+    hasWatched,
+    watchTogetherness,
+    toggleSeenBy,
     type GeoLocation,
 } from "./types"
+
+function media(patch: Partial<Media>): Media {
+    return {
+        type: "movie",
+        title: "Test",
+        status: "queued",
+        rating: null,
+        notes: "",
+        posterPath: null,
+        createdBy: "Z",
+        ...patch,
+    } as Media
+}
 
 describe("Type definitions", () => {
     describe("UserId", () => {
@@ -668,6 +684,52 @@ describe("Type definitions", () => {
             it("should handle invalid budget levels", () => {
                 expect(getBudgetLabel(5)).toBe("Unknown")
                 expect(getBudgetLabel(-1)).toBe("Unknown")
+            })
+        })
+    })
+
+    describe("Couple watch-state", () => {
+        describe("hasWatched", () => {
+            it("is true when the user is in seenBy", () => {
+                expect(hasWatched(media({ seenBy: ["Z"] }), "Z")).toBe(true)
+                expect(hasWatched(media({ seenBy: ["Z"] }), "T")).toBe(false)
+            })
+            it("infers watched from a personal rating", () => {
+                expect(hasWatched(media({ ratings: { Z: 4, T: null } }), "Z")).toBe(true)
+                expect(hasWatched(media({ ratings: { Z: 4, T: null } }), "T")).toBe(false)
+            })
+            it("ignores the legacy shared rating (not attributable)", () => {
+                expect(hasWatched(media({ rating: 5 }), "Z")).toBe(false)
+                expect(hasWatched(media({ rating: 5 }), "T")).toBe(false)
+            })
+            it("is false for an untouched title", () => {
+                expect(hasWatched(media({}), "Z")).toBe(false)
+            })
+        })
+
+        describe("watchTogetherness", () => {
+            it("classifies both / mine / theirs / none from the viewer POV", () => {
+                expect(watchTogetherness(media({ seenBy: ["Z", "T"] }), "Z", "T")).toBe("both")
+                expect(watchTogetherness(media({ seenBy: ["Z"] }), "Z", "T")).toBe("mine")
+                expect(watchTogetherness(media({ seenBy: ["Z"] }), "T", "Z")).toBe("theirs")
+                expect(watchTogetherness(media({}), "Z", "T")).toBe("none")
+            })
+            it("mixes seenBy and inferred ratings", () => {
+                // Z rated it (inferred seen), T explicitly marked seen.
+                const m = media({ ratings: { Z: 5, T: null }, seenBy: ["T"] })
+                expect(watchTogetherness(m, "Z", "T")).toBe("both")
+            })
+        })
+
+        describe("toggleSeenBy", () => {
+            it("adds a user not present", () => {
+                expect(toggleSeenBy(media({ seenBy: [] }), "Z")).toEqual(["Z"])
+            })
+            it("removes a user present, preserving canonical order", () => {
+                expect(toggleSeenBy(media({ seenBy: ["Z", "T"] }), "Z")).toEqual(["T"])
+            })
+            it("handles missing seenBy", () => {
+                expect(toggleSeenBy(media({}), "T")).toEqual(["T"])
             })
         })
     })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -143,6 +143,7 @@ export interface Media extends BaseDocument {
     status: MediaStatus
     rating: number | null // Legacy field for backward compatibility
     ratings?: Record<UserId, number | null> // Per-user ratings
+    seenBy?: UserId[] // Which partners have personally watched this (couple watch-state)
     notes: string
     progress?: MediaProgress
     // Metadata fields
@@ -195,6 +196,40 @@ export function getAverageRating(media: Media): number | null {
 export function getDisplayRating(media: Media): number | null {
     // Priority: average of both ratings > individual rating > legacy rating
     return getAverageRating(media)
+}
+
+// ===== Couple watch-state =====
+// From the viewer's perspective, how this title sits between the two partners.
+export type TogethernessState = "both" | "mine" | "theirs" | "none"
+
+/**
+ * Has this specific partner personally watched the title? True when they're in
+ * `seenBy`, or (zero-effort backfill) when they've left a personal rating —
+ * a per-user rating implies they watched it. The legacy shared `rating` is
+ * intentionally ignored here since it isn't attributable to one partner.
+ */
+export function hasWatched(media: Media, user: UserId): boolean {
+    if (media.seenBy?.includes(user)) return true
+    const r = media.ratings?.[user]
+    return r !== null && r !== undefined
+}
+
+/** Classify a title by who of the pair has seen it, from `viewer`'s POV. */
+export function watchTogetherness(media: Media, viewer: UserId, partner: UserId): TogethernessState {
+    const mine = hasWatched(media, viewer)
+    const theirs = hasWatched(media, partner)
+    if (mine && theirs) return "both"
+    if (mine) return "mine"
+    if (theirs) return "theirs"
+    return "none"
+}
+
+/** Toggle a partner's personal "watched" flag, returning the next seenBy list. */
+export function toggleSeenBy(media: Media, user: UserId): UserId[] {
+    const set = new Set(media.seenBy ?? [])
+    if (set.has(user)) set.delete(user)
+    else set.add(user)
+    return ALL_USER_IDS.filter(u => set.has(u))
 }
 
 export type PlaceCategory =


### PR DESCRIPTION
Child PR **N** — a couple-native feature for the media library.

The library had one *shared* status, so there was no way to say "I've watched this, she hasn't." This adds a per-person watch layer and surfaces the asymmetry as a first-class way to browse.

### Model (`types.ts`, unit-tested)
- `Media.seenBy?: UserId[]` — who has personally watched it.
- `hasWatched(media, user)` — true if in `seenBy` **or** they left a personal rating (a per-user rating implies watched, so existing data is classified for free; the legacy shared rating is ignored since it isn't attributable).
- `watchTogetherness(media, viewer, partner)` → `both | mine | theirs | none`, from the viewer's POV.
- `toggleSeenBy(media, user)` → next canonical `seenBy`.

### Library
- **"Between Us" lens** — a segmented row with live counts: **All · New to us · Waiting on you** (partner's seen, you haven't) **· Waiting on {partner}** (you've seen, they haven't) **· Seen together**. Filters the grid from *your* perspective.
- **Per-card seen-by faces** — two little initials (Z/T); filled in that partner's accent with a ✓ when watched, dashed outline when not. Tap either to mark that partner watched.

### Detail modal
- An authoritative **"Watched by"** toggle per partner, next to the ratings.

## Why this approach
It reuses the data you already generate (per-user ratings backfill "seen" with zero effort), reads from *your* side of the couch ("waiting on you" vs "waiting on them"), and turns the pain point directly into a browse axis rather than a buried flag.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — 299 / 299 (13 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_