### PR TITLE
[P] Notes: intelligent select-mode dismissal

### DIFF
--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -363,12 +363,42 @@
     selectMode = !selectMode
     selectedIds = new Set()
   }
+  function exitSelect(): void {
+    selectMode = false
+    selectedIds = new Set()
+  }
   function toggleSelected(id: string | undefined): void {
     if (!id) return
     const s = new Set(selectedIds)
     if (s.has(id)) s.delete(id); else s.add(id)
     selectedIds = s
   }
+
+  // Escape closes the context menu, else leaves select mode (when no modal is up).
+  function onWindowKeydown(e: KeyboardEvent): void {
+    if (e.key !== 'Escape') return
+    if (contextFor) { closeContext(); return }
+    if (selectedNote || threadRootId || editingNote || pendingConfirm) return
+    if (selectMode) exitSelect()
+  }
+
+  // While selecting, a tap on empty board space (not a note, control, menu, or
+  // modal) clears the selection first, then exits — so select mode never feels
+  // sticky. Handled at the document level to keep the board markup clean.
+  $effect(() => {
+    if (!selectMode) return
+    const handler = (e: MouseEvent) => {
+      const t = e.target as HTMLElement
+      if (t.closest('.sticky-note') || t.closest('.cork-rail') || t.closest('.filter-tray')
+        || t.closest('.bulk-bar') || t.closest('.compose-sticky') || t.closest('.context-menu')
+        || t.closest('.reaction-backdrop') || t.closest('.thread-expanded')
+        || t.closest('[role="dialog"]')) return
+      if (selectedIds.size > 0) selectedIds = new Set()
+      else exitSelect()
+    }
+    document.addEventListener('click', handler)
+    return () => document.removeEventListener('click', handler)
+  })
   async function bulkArchive(): Promise<void> {
     hapticLight()
     for (const id of selectedIds) await updateDocument<Note>('notes', id, { archived: true }, $activeUser)
@@ -684,6 +714,8 @@
   })
 </script>
 
+<svelte:window onkeydown={onWindowKeydown} />
+
 <!-- Full-bleed cork backdrop (fixed behind the page content) -->
 <div class="cork-backdrop" style={corkStyle} aria-hidden="true"></div>
 
@@ -740,7 +772,7 @@
       <button
         type="button"
         class="rail-btn {activeView === 'archive' ? 'is-active' : ''}"
-        onclick={() => { activeView = activeView === 'corkboard' ? 'archive' : 'corkboard'; hapticLight(); }}
+        onclick={() => { activeView = activeView === 'corkboard' ? 'archive' : 'corkboard'; exitSelect(); hapticLight(); }}
         aria-label={activeView === 'archive' ? 'Back to board' : 'Open archive'}
       >
         {#if activeView === 'archive'}
@@ -755,7 +787,7 @@
         <button
           type="button"
           class="rail-pen"
-          onclick={() => { composing = !composing; hapticLight(); }}
+          onclick={() => { composing = !composing; if (composing) exitSelect(); hapticLight(); }}
           aria-label="Write a note"
         >
           <Pencil size={15} />


### PR DESCRIPTION
Child PR **P** — make leaving select mode effortless.

Previously the only way out of select mode was toggling the rail button off. Now it exits when it naturally should, without ever feeling sticky:

- **Tap empty board space** → clears the selection first (if anything's selected), then exits. Done at the document level so it correctly ignores taps on notes, the rail, the filter tray, the bulk bar, the compose sheet, the long-press menu, and any modal.
- **Escape** → closes the context menu if open, otherwise leaves select mode (only when no modal is up).
- **Opening the archive** or **starting a new note** exits select mode.

(Bulk actions already dropped out of select mode; that's unchanged.)

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — 299 / 299

## Also (not in this diff)
Stubbed & queued the two remaining media candidates as issues, sequenced after the Videos/YouTube + Grayjay work (#63): **#86** (asymmetry sort + nudge) and **#87** (solo vs. together provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_