### PR TITLE
[Q] Notes: first-class stack-view control; extract + test stack grouping

### DIFF
--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -6,7 +6,7 @@
   import { hapticLight } from '$lib/haptics'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { UserId } from '$lib/types'
-  import { clampPosition, flyoutPlacement } from '$lib/identityPill'
+  import { clampPosition, flyoutPlacement, centerOf } from '$lib/identityPill'
 
   const STORAGE_KEY = 'identity-pill-pos'
   const DRAG_THRESHOLD = 6
@@ -54,7 +54,7 @@
   function computePlacement(): void {
     if (!pillEl) return
     const rect = pillEl.getBoundingClientRect()
-    const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+    const center = centerOf({ x: rect.left, y: rect.top }, { width: rect.width, height: rect.height })
     const p = flyoutPlacement(center, { width: window.innerWidth, height: window.innerHeight })
     openLeft = p.openLeft
     openUp = p.openUp

--- a/src/lib/noteStacks.test.ts
+++ b/src/lib/noteStacks.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest"
+import {
+    isoWeekYear,
+    dateBucket,
+    tokenize,
+    similarityClusters,
+    threadKeyOf,
+    groupKeyOf,
+    isStackView,
+    type StackableNote,
+} from "./noteStacks"
+
+// Local-time constructor so buckets (which use local calendar fields) are stable
+// regardless of the runner's timezone.
+const at = (y: number, m: number, d: number, h = 12): number => new Date(y, m, d, h).getTime()
+
+const note = (patch: Partial<StackableNote> & { createdAtMs: number }): StackableNote => ({
+    id: "n1",
+    ...patch,
+})
+
+describe("noteStacks", () => {
+    describe("isStackView", () => {
+        it("accepts known views and rejects anything else", () => {
+            expect(isStackView("custom")).toBe(true)
+            expect(isStackView("similar")).toBe(true)
+            expect(isStackView("nope")).toBe(false)
+            expect(isStackView(undefined)).toBe(false)
+        })
+    })
+
+    describe("isoWeekYear", () => {
+        it("computes a mid-year week", () => {
+            // 2026-08-12 is a Wednesday in ISO week 33.
+            expect(isoWeekYear(new Date(2026, 7, 12))).toEqual({ year: 2026, week: 33 })
+        })
+
+        it("assigns early-January days to the previous ISO year when they belong to it", () => {
+            // 2027-01-01 is a Friday → ISO week 53 of 2026.
+            expect(isoWeekYear(new Date(2027, 0, 1))).toEqual({ year: 2026, week: 53 })
+        })
+
+        it("assigns late-December days to the next ISO year when they belong to it", () => {
+            // 2024-12-30 is a Monday → ISO week 1 of 2025.
+            expect(isoWeekYear(new Date(2024, 11, 30))).toEqual({ year: 2025, week: 1 })
+        })
+    })
+
+    describe("dateBucket", () => {
+        it("buckets by day, month and year", () => {
+            const ms = at(2026, 7, 12)
+            expect(dateBucket(ms, "day")).toBe("d:2026-7-12")
+            expect(dateBucket(ms, "month")).toBe("m:2026-7")
+            expect(dateBucket(ms, "year")).toBe("y:2026")
+        })
+
+        it("separates different days in the same month", () => {
+            expect(dateBucket(at(2026, 7, 12), "day")).not.toBe(dateBucket(at(2026, 7, 13), "day"))
+        })
+
+        it("keeps one ISO week together across a calendar-year boundary", () => {
+            // Dec 31 2026 (Thu) and Jan 1 2027 (Fri) are the same ISO week.
+            const dec = dateBucket(at(2026, 11, 31), "week")
+            const jan = dateBucket(at(2027, 0, 1), "week")
+            expect(dec).toBe(jan)
+        })
+
+        it("still separates genuinely different weeks", () => {
+            expect(dateBucket(at(2026, 7, 12), "week")).not.toBe(dateBucket(at(2026, 7, 20), "week"))
+        })
+    })
+
+    describe("tokenize", () => {
+        it("keeps only significant (>3 char) words, lowercased", () => {
+            expect(tokenize("Dinner at Luigi's", "It was so good")).toEqual(
+                new Set(["dinner", "luigi", "good"]),
+            )
+        })
+        it("handles missing fields", () => {
+            expect(tokenize(undefined, undefined)).toEqual(new Set())
+        })
+    })
+
+    describe("similarityClusters", () => {
+        it("groups notes sharing enough significant words", () => {
+            const notes: StackableNote[] = [
+                { id: "a", title: "Pizza night", content: "Luigi restaurant was great", createdAtMs: at(2026, 0, 1) },
+                { id: "b", title: "Pizza again", content: "Luigi restaurant repeat", createdAtMs: at(2026, 0, 2) },
+            ]
+            const map = similarityClusters(notes)
+            expect(map.get("b")).toBe(map.get("a"))
+        })
+
+        it("leaves unrelated notes in their own clusters", () => {
+            const notes: StackableNote[] = [
+                { id: "a", title: "Pizza night", content: "Luigi restaurant", createdAtMs: at(2026, 0, 1) },
+                { id: "b", title: "Hiking trail", content: "Mountain sunrise", createdAtMs: at(2026, 0, 2) },
+            ]
+            const map = similarityClusters(notes)
+            expect(map.get("a")).toBe("a")
+            expect(map.get("b")).toBe("b")
+        })
+
+        it("roots a cluster at its oldest note regardless of input order", () => {
+            const notes: StackableNote[] = [
+                { id: "new", title: "Pizza again", content: "Luigi restaurant repeat", createdAtMs: at(2026, 0, 9) },
+                { id: "old", title: "Pizza night", content: "Luigi restaurant great", createdAtMs: at(2026, 0, 1) },
+            ]
+            const map = similarityClusters(notes)
+            expect(map.get("new")).toBe("old")
+            expect(map.get("old")).toBe("old")
+        })
+
+        it("ignores notes without an id", () => {
+            const map = similarityClusters([{ title: "x", content: "y", createdAtMs: 0 }])
+            expect(map.size).toBe(0)
+        })
+
+        it("returns an empty map for no notes", () => {
+            expect(similarityClusters([]).size).toBe(0)
+        })
+    })
+
+    describe("threadKeyOf", () => {
+        it("prefers threadId, falls back to the note's own id", () => {
+            expect(threadKeyOf({ id: "n1", threadId: "root" })).toBe("root")
+            expect(threadKeyOf({ id: "n1" })).toBe("n1")
+            expect(threadKeyOf({})).toBe("")
+        })
+    })
+
+    describe("groupKeyOf", () => {
+        it("uses manual threads for the custom view", () => {
+            const n = note({ id: "n1", threadId: "root", createdAtMs: at(2026, 7, 12) })
+            expect(groupKeyOf(n, "custom")).toBe("root")
+        })
+
+        it("uses date buckets for date views, ignoring thread links", () => {
+            const n = note({ id: "n1", threadId: "root", createdAtMs: at(2026, 7, 12) })
+            expect(groupKeyOf(n, "day")).toBe("d:2026-7-12")
+        })
+
+        it("uses the similarity map for the similar view", () => {
+            const n = note({ id: "n1", createdAtMs: at(2026, 7, 12) })
+            expect(groupKeyOf(n, "similar", new Map([["n1", "cluster"]]))).toBe("cluster")
+        })
+
+        it("falls back to the note id when similarity has no entry", () => {
+            const n = note({ id: "n1", createdAtMs: at(2026, 7, 12) })
+            expect(groupKeyOf(n, "similar", new Map())).toBe("n1")
+        })
+    })
+})

--- a/src/lib/noteStacks.ts
+++ b/src/lib/noteStacks.ts
@@ -1,0 +1,103 @@
+// Pure grouping logic for the notes board's stack "views". Kept free of
+// Svelte/Firestore types so it can be unit-tested directly; callers pass plain
+// millisecond timestamps.
+
+export type StackView = "custom" | "day" | "week" | "month" | "year" | "similar"
+
+export const STACK_VIEW_KEYS: StackView[] = ["custom", "day", "week", "month", "year", "similar"]
+
+export function isStackView(value: unknown): value is StackView {
+    return typeof value === "string" && (STACK_VIEW_KEYS as string[]).includes(value)
+}
+
+/** A note reduced to just what grouping needs. */
+export interface StackableNote {
+    id?: string
+    threadId?: string
+    title?: string
+    content?: string
+    createdAtMs: number
+}
+
+/**
+ * ISO-8601 week number *and* its ISO week-year. The week-year is returned
+ * because it can differ from the calendar year at the boundary (e.g. Jan 1 can
+ * belong to week 52/53 of the previous ISO year) — keying a week bucket by the
+ * calendar year would split one week into two stacks.
+ */
+export function isoWeekYear(d: Date): { year: number; week: number } {
+    const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+    const day = date.getUTCDay() || 7
+    date.setUTCDate(date.getUTCDate() + 4 - day) // shift to the week's Thursday
+    const year = date.getUTCFullYear()
+    const yearStart = new Date(Date.UTC(year, 0, 1))
+    const week = Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
+    return { year, week }
+}
+
+/** Bucket key for the date-based views. `view` must not be custom/similar. */
+export function dateBucket(createdAtMs: number, view: StackView): string {
+    const d = new Date(createdAtMs)
+    const y = d.getFullYear()
+    if (view === "year") return `y:${y}`
+    if (view === "month") return `m:${y}-${d.getMonth()}`
+    if (view === "week") {
+        const { year, week } = isoWeekYear(d)
+        return `w:${year}-${week}`
+    }
+    return `d:${y}-${d.getMonth()}-${d.getDate()}`
+}
+
+/** Significant words of a note, for the "similar" view. */
+export function tokenize(title?: string, content?: string): Set<string> {
+    const text = `${title ?? ""} ${content ?? ""}`.toLowerCase()
+    return new Set(text.split(/[^a-z0-9]+/).filter(w => w.length > 3))
+}
+
+/** Minimum shared significant words for two notes to land in one cluster. */
+export const SIMILARITY_THRESHOLD = 2
+
+/**
+ * Greedy similarity clustering: oldest first, each note joins the cluster it
+ * shares the most significant words with (when over the threshold), else it
+ * starts its own. Returns note id -> cluster key.
+ */
+export function similarityClusters(notes: StackableNote[]): Map<string, string> {
+    const map = new Map<string, string>()
+    const sorted = [...notes].filter(n => n.id).sort((a, b) => a.createdAtMs - b.createdAtMs)
+    const clusters: Array<{ key: string; tokens: Set<string> }> = []
+    for (const n of sorted) {
+        const toks = tokenize(n.title, n.content)
+        let best: { key: string; tokens: Set<string> } | null = null
+        let bestScore = 0
+        for (const c of clusters) {
+            let score = 0
+            for (const t of toks) if (c.tokens.has(t)) score++
+            if (score > bestScore) { bestScore = score; best = c }
+        }
+        if (best && bestScore >= SIMILARITY_THRESHOLD) {
+            map.set(n.id!, best.key)
+            for (const t of toks) best.tokens.add(t)
+        } else {
+            clusters.push({ key: n.id!, tokens: toks })
+            map.set(n.id!, n.id!)
+        }
+    }
+    return map
+}
+
+/** The manual (reply-thread) stack a note belongs to. */
+export function threadKeyOf(n: Pick<StackableNote, "id" | "threadId">): string {
+    return n.threadId ?? n.id ?? ""
+}
+
+/** The stack a note belongs to under the given view. */
+export function groupKeyOf(
+    n: StackableNote,
+    view: StackView,
+    similarity?: Map<string, string>,
+): string {
+    if (view === "custom") return threadKeyOf(n)
+    if (view === "similar") return similarity?.get(n.id ?? "") ?? n.id ?? ""
+    return dateBucket(n.createdAtMs, view)
+}

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -9,6 +9,14 @@
   import { consumeQueryParam } from '$lib/stores/nav'
   import { getNotePalette, resolveNoteTone, resolveToneShift, NOTE_TONE_KEYS, type NoteTone } from '$lib/notePalette'
   import { readableInk, ensureReadable } from '$lib/color'
+  import {
+    similarityClusters,
+    threadKeyOf,
+    groupKeyOf as groupKey,
+    isStackView,
+    type StackView,
+    type StackableNote,
+  } from '$lib/noteStacks'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import type { Note, NoteColor, UserId } from '$lib/types'
   import { Timestamp, type Timestamp as TimestampType } from 'firebase/firestore'
@@ -51,16 +59,17 @@
 
   // How notes are grouped into stacks on the board. "custom" honours the manual
   // reply-thread links; the others are non-destructive views over the same notes.
-  type StackView = 'custom' | 'day' | 'week' | 'month' | 'year' | 'similar'
   let stackView = $state<StackView>('custom')
-  const STACK_VIEWS: Array<{ key: StackView; label: string }> = [
-    { key: 'custom', label: 'My stacks' },
-    { key: 'day', label: 'Day' },
-    { key: 'week', label: 'Week' },
-    { key: 'month', label: 'Month' },
-    { key: 'year', label: 'Year' },
-    { key: 'similar', label: 'Similar' },
+  let showStackMenu = $state(false)
+  const STACK_VIEWS: Array<{ key: StackView; label: string; hint: string }> = [
+    { key: 'custom', label: 'My stacks', hint: 'Threads you linked yourself' },
+    { key: 'day', label: 'By day', hint: 'Grouped by the day posted' },
+    { key: 'week', label: 'By week', hint: 'Grouped by week' },
+    { key: 'month', label: 'By month', hint: 'Grouped by month' },
+    { key: 'year', label: 'By year', hint: 'Grouped by year' },
+    { key: 'similar', label: 'Similar', hint: 'Loosely grouped by shared words' },
   ]
+  let stackViewDef = $derived(STACK_VIEWS.find(s => s.key === stackView) ?? STACK_VIEWS[0])
 
   // Filter / sort state
   let showFilters = $state(false)
@@ -168,8 +177,9 @@
     try {
       const v = sessionStorage.getItem('notes-board-view')
       if (v === 'new' || v === 'all') boardView = v
-      const sv = sessionStorage.getItem('notes-stack-view')
-      if (sv && STACK_VIEWS.some(s => s.key === sv)) stackView = sv as StackView
+      // Stack view is a lasting view preference, so it persists across sessions.
+      const sv = localStorage.getItem('notes-stack-view')
+      if (isStackView(sv)) stackView = sv
     } catch { /* private mode */ }
 
     unsubscribe = subscribeToCollection<Note>('notes', (items) => {
@@ -345,7 +355,7 @@
 
   // How many notes are in the tapped note's current stack (for "expand thread").
   function stackSizeOf(note: Note): number {
-    return notes.filter(n => !n.archived && groupKeyOf(n) === groupKeyOf(note)).length
+    return stackSizes.get(groupKeyOf(note)) ?? 1
   }
   // "Expand stack": unstack the linked notes in a linear, yarn-threaded strip
   // laid out on the corkboard itself (not a modal).
@@ -378,9 +388,20 @@
   function onWindowKeydown(e: KeyboardEvent): void {
     if (e.key !== 'Escape') return
     if (contextFor) { closeContext(); return }
+    if (showStackMenu) { showStackMenu = false; return }
     if (selectedNote || threadRootId || editingNote || pendingConfirm) return
     if (selectMode) exitSelect()
   }
+
+  // Dismiss the stack-view menu on any click outside it.
+  $effect(() => {
+    if (!showStackMenu) return
+    const handler = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement).closest('.stack-picker')) showStackMenu = false
+    }
+    document.addEventListener('click', handler)
+    return () => document.removeEventListener('click', handler)
+  })
 
   // While selecting, a tap on empty board space (not a note, control, menu, or
   // modal) clears the selection first, then exits — so select mode never feels
@@ -473,8 +494,17 @@
     try { sessionStorage.setItem('notes-board-view', boardView) } catch { /* private mode */ }
   })
   $effect(() => {
-    try { sessionStorage.setItem('notes-stack-view', stackView) } catch { /* private mode */ }
+    try { localStorage.setItem('notes-stack-view', stackView) } catch { /* private mode */ }
   })
+
+  function selectStackView(key: StackView): void {
+    stackView = key
+    showStackMenu = false
+    // A regrouping invalidates any expanded stack from the previous grouping.
+    expandedStackKey = null
+    threadRootId = null
+    hapticLight()
+  }
 
   // Confirm dialog state
   let pendingConfirm = $state<{ message: string; onConfirm: () => void } | null>(null)
@@ -576,63 +606,31 @@
     })
   })
 
-  function threadKeyOf(n: Note): string {
-    return n.threadId ?? n.id ?? ''
+  // ===== Stack grouping (view-dependent; pure logic lives in noteStacks.ts) =====
+  function stackable(n: Note): StackableNote {
+    return { id: n.id, threadId: n.threadId, title: n.title, content: n.content, createdAtMs: n.createdAt?.toMillis?.() ?? 0 }
+  }
+  let similarityKeys = $derived(
+    stackView === 'similar'
+      ? similarityClusters(notes.filter(n => !n.archived).map(stackable))
+      : new Map<string, string>()
+  )
+  /** The stack a note belongs to under the current view. */
+  function groupKeyOf(n: Note): string {
+    return groupKey(stackable(n), stackView, similarityKeys)
   }
 
-  // ===== Stack grouping (view-dependent) =====
-  function isoWeek(d: Date): number {
-    const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
-    const day = date.getUTCDay() || 7
-    date.setUTCDate(date.getUTCDate() + 4 - day)
-    const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
-    return Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7)
-  }
-  function dateBucket(n: Note): string {
-    const d = n.createdAt?.toDate?.() ?? new Date(0)
-    const y = d.getFullYear()
-    if (stackView === 'year') return `y:${y}`
-    if (stackView === 'month') return `m:${y}-${d.getMonth()}`
-    if (stackView === 'week') return `w:${y}-${isoWeek(d)}`
-    return `d:${y}-${d.getMonth()}-${d.getDate()}`
-  }
-  function noteTokens(n: Note): Set<string> {
-    const text = `${n.title ?? ''} ${n.content ?? ''}`.toLowerCase()
-    return new Set(text.split(/[^a-z0-9]+/).filter(w => w.length > 3))
-  }
-  // Simplistic greedy similarity clustering: a note joins the first cluster it
-  // shares enough significant words with, else it starts its own. Just for fun.
-  let similarityKeys = $derived.by(() => {
-    const map = new Map<string, string>()
-    if (stackView !== 'similar') return map
-    const sorted = [...notes.filter(n => !n.archived && n.id)]
-      .sort((a, b) => (a.createdAt?.toMillis?.() ?? 0) - (b.createdAt?.toMillis?.() ?? 0))
-    const clusters: Array<{ key: string; tokens: Set<string> }> = []
-    for (const n of sorted) {
-      const toks = noteTokens(n)
-      let best: { key: string; tokens: Set<string> } | null = null
-      let bestScore = 0
-      for (const c of clusters) {
-        let score = 0
-        for (const t of toks) if (c.tokens.has(t)) score++
-        if (score > bestScore) { bestScore = score; best = c }
-      }
-      if (best && bestScore >= 2) {
-        map.set(n.id!, best.key)
-        for (const t of toks) best.tokens.add(t)
-      } else {
-        clusters.push({ key: n.id!, tokens: toks })
-        map.set(n.id!, n.id!)
-      }
+  // Full (unfiltered) size of every stack, in one pass — a stack's badge counts
+  // all its notes even when filters hide some of them.
+  let stackSizes = $derived.by(() => {
+    const sizes = new Map<string, number>()
+    for (const n of notes) {
+      if (n.archived) continue
+      const key = groupKeyOf(n)
+      sizes.set(key, (sizes.get(key) ?? 0) + 1)
     }
-    return map
+    return sizes
   })
-  // The stack a note belongs to under the current view.
-  function groupKeyOf(n: Note): string {
-    if (stackView === 'custom') return threadKeyOf(n)
-    if (stackView === 'similar') return similarityKeys.get(n.id ?? '') ?? n.id ?? ''
-    return dateBucket(n)
-  }
 
   // Group the filtered board into stacks; each renders with a face (most recent
   // note), sorted like the flat board.
@@ -643,10 +641,9 @@
       const arr = groups.get(key)
       if (arr) arr.push(n); else groups.set(key, [n])
     }
-    const fullCount = (key: string) => notes.filter(n => !n.archived && groupKeyOf(n) === key).length
     const list = [...groups.entries()].map(([key, ns]) => {
       const face = [...ns].sort((a, b) => (b.createdAt?.toMillis?.() ?? 0) - (a.createdAt?.toMillis?.() ?? 0))[0]
-      return { key, face, count: fullCount(key) }
+      return { key, face, count: stackSizes.get(key) ?? ns.length }
     })
     return list.sort((a, b) => {
       if (a.face.pinned && !b.face.pinned) return -1
@@ -680,8 +677,7 @@
   // otherwise the single note's detail.
   function openThread(key: string, face: Note): void {
     if (selectMode) { toggleSelected(face.id); return }
-    const count = notes.filter(n => !n.archived && groupKeyOf(n) === key).length
-    if (count > 1) { threadRootId = key; markAsRead(face) }
+    if ((stackSizes.get(key) ?? 1) > 1) { threadRootId = key; markAsRead(face) }
     else openNoteDetail(face)
   }
 
@@ -745,6 +741,43 @@
             New{#if unreadCount > 0}<span class="view-badge">{unreadCount}</span>{/if}
           </button>
           <button type="button" class="view-seg {boardView === 'all' ? 'is-on' : ''}" onclick={() => { boardView = 'all'; hapticLight(); }}>All</button>
+        </div>
+
+        <!-- Stack view: a first-class (but quiet) view modifier -->
+        <div class="stack-picker">
+          <button
+            type="button"
+            class="rail-btn {showStackMenu || stackView !== 'custom' ? 'is-active' : ''}"
+            onclick={(e) => { e.stopPropagation(); showStackMenu = !showStackMenu; hapticLight(); }}
+            aria-label="Stack view: {stackViewDef.label}"
+            aria-haspopup="menu"
+            aria-expanded={showStackMenu}
+            title="Stack view: {stackViewDef.label}"
+          >
+            <Layers size={16} />
+            {#if stackView !== 'custom'}<span class="rail-tag">{stackViewDef.label}</span>{/if}
+          </button>
+
+          {#if showStackMenu}
+            <div class="stack-menu" role="menu">
+              <p class="stack-menu-head">Stack notes by</p>
+              {#each STACK_VIEWS as sv (sv.key)}
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={stackView === sv.key}
+                  class="stack-opt {stackView === sv.key ? 'is-on' : ''}"
+                  onclick={() => selectStackView(sv.key)}
+                >
+                  <span class="stack-opt-main">
+                    <span class="stack-opt-label">{sv.label}</span>
+                    <span class="stack-opt-hint">{sv.hint}</span>
+                  </span>
+                  {#if stackView === sv.key}<Check size={15} />{/if}
+                </button>
+              {/each}
+            </div>
+          {/if}
         </div>
 
         <button
@@ -832,15 +865,6 @@
           <option value="newest">Newest</option>
           <option value="oldest">Oldest</option>
           <option value="author">By author</option>
-        </select>
-      </label>
-
-      <label class="tray-sort">
-        <Layers size={14} class="text-slate-400" />
-        <select bind:value={stackView} aria-label="Stack notes by">
-          {#each STACK_VIEWS as sv}
-            <option value={sv.key}>{sv.label}</option>
-          {/each}
         </select>
       </label>
 
@@ -1519,6 +1543,61 @@
   }
   .rail-btn:hover { background: rgba(255,255,255,0.2); }
   .rail-btn.is-active { background: var(--color-accent); }
+
+  /* ===== Stack-view picker (rail) ===== */
+  .stack-picker { position: relative; }
+  .rail-tag {
+    margin-left: 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+  }
+  .stack-menu {
+    position: absolute;
+    z-index: 40;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: 15rem;
+    max-width: calc(100vw - 2rem);
+    padding: 0.4rem;
+    border-radius: 0.9rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 12px 32px rgba(0,0,0,0.28);
+    animation: stackpop 0.13s ease-out;
+  }
+  @keyframes stackpop { from { opacity: 0; transform: translateY(-4px); } }
+  .stack-menu-head {
+    padding: 0.25rem 0.55rem 0.4rem;
+    font-size: 0.66rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--color-text-hint, #78716c);
+  }
+  .stack-opt {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.5rem 0.55rem;
+    border-radius: 0.6rem;
+    text-align: left;
+    color: var(--color-text);
+    transition: background 120ms;
+  }
+  .stack-opt:hover { background: var(--color-surface-2); }
+  .stack-opt.is-on { color: var(--color-accent); }
+  .stack-opt-main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+  .stack-opt-label { font-size: 0.85rem; font-weight: 600; }
+  .stack-opt-hint {
+    font-size: 0.68rem;
+    color: var(--color-text-hint, #78716c);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   .rail-badge {
     margin-left: 0.3rem;


### PR DESCRIPTION
Child PR **Q** — the stack-view control, plus the first slice of the cleanup pass.

### Stack views are now first-class (and persistent)
- Promoted from a select buried in the Filters tray to a quiet control on the board rail: a **Layers** button (which shows the view's name when you're off the default) opening a small menu with a one-line hint per view. Dismisses on outside click or Escape.
- **Persists across sessions** (localStorage, was session-only), validated through a shared type guard rather than an ad-hoc string check.
- Switching views now clears any expanded/open stack from the previous grouping — it would otherwise hold a key that no longer exists in the new grouping.

### Extraction, correctness, perf
- Grouping logic moved into a pure, unit-tested **`noteStacks.ts`** (`isoWeekYear` / `dateBucket` / `tokenize` / `similarityClusters` / `threadKeyOf` / `groupKeyOf`), out of the component.
- **Bug fix (found while extracting):** week buckets were keyed by the *calendar* year while the week number is *ISO*, so a single ISO week spanning New Year split into two stacks — e.g. Dec 31 2026 and Jan 1 2027 are the same ISO week but landed in `w:2026-53` and `w:2027-53`. Now keyed by ISO week-year; covered by tests at both boundaries.
- **Perf:** stack sizes were recomputed per group by re-scanning every note (O(groups × notes)) — replaced with a single-pass size map, reused by the stack badge, "Expand stack", and tap-to-open.
- `IdentityPill` now uses the tested `centerOf` helper instead of duplicating the centre math inline.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — **319 / 319** (20 new)

A broader audit of everything touched this session is running; follow-ups will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_