### PR TITLE
[S] Fix defects found auditing the full session diff

### DIFF
--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -135,10 +135,6 @@ export function shiftHue(hex: string, degrees: number): string {
     return hslToHex({ ...hsl, h: hsl.h + degrees })
 }
 
-export function withHsl(hex: string, patch: Partial<HSL>): string {
-    return hslToHex({ ...hexToHsl(hex), ...patch })
-}
-
 /** Smallest absolute distance between two hues, in degrees (0..180). */
 export function hueDistance(a: number, b: number): number {
     const d = Math.abs(((a - b) % 360 + 360) % 360)

--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -90,6 +90,9 @@
         { width: window.innerWidth, height: window.innerHeight },
         EDGE_MARGIN,
       )
+      // Dragging across the viewport midpoint has to flip the panel, or an
+      // open fly-out ends up hanging off the edge it was dragged toward.
+      if (isExpanded) computePlacement()
     }
   }
 

--- a/src/lib/components/MediaDetailModal.svelte
+++ b/src/lib/components/MediaDetailModal.svelte
@@ -3,7 +3,7 @@
   import { updateDocument } from '$lib/firebase'
   import { activeUser, displayNames, displayAbbreviations, userPreferences } from '$lib/stores/app'
   import type { Media, MediaComment, MediaStatus, UserId } from '$lib/types'
-  import { getUserRating, getAverageRating, hasWatched, toggleSeenBy } from '$lib/types'
+  import { getUserRating, getAverageRating, hasWatched, toggleWatched } from '$lib/types'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import { Timestamp } from 'firebase/firestore'
   import { Film, Tv, Gamepad2 } from 'lucide-svelte'
@@ -100,7 +100,7 @@
   async function toggleSeen(userId: UserId): Promise<void> {
     if (!media?.id) return
     hapticLight()
-    await updateDocument<Media>('media', media.id, { seenBy: toggleSeenBy(media, userId) }, $activeUser)
+    await updateDocument<Media>('media', media.id, toggleWatched(media, userId), $activeUser)
   }
 
   async function updateRating(userId: UserId, starIndex: number): Promise<void> {

--- a/src/lib/components/PlaceDetailModal.svelte
+++ b/src/lib/components/PlaceDetailModal.svelte
@@ -41,11 +41,19 @@
   let mapEl = $state<HTMLDivElement | null>(null)
   let miniMap: LeafletMap | undefined
 
+  // Depend on primitives, not the `place` object: the parent reassigns the
+  // selected place on every Firestore snapshot, and depending on the object
+  // would tear down and rebuild the map (losing the user's zoom and re-fetching
+  // tiles) on every unrelated write — a rating tap, a notes blur, a visit toggle.
+  let pinLat = $derived(place?.location?.lat ?? null)
+  let pinLng = $derived(place?.location?.lng ?? null)
+  let pinColor = $derived(place ? categoryDef(place.category).color : '')
+  let pinEmoji = $derived(place ? categoryDef(place.category).emoji : '')
+
   $effect(() => {
-    const loc = place?.location
+    const lat = pinLat, lng = pinLng, color = pinColor, emoji = pinEmoji
     const el = mapEl
-    if (!loc || !el) return
-    const def = categoryDef(place!.category)
+    if (lat === null || lng === null || !el) return
     let disposed = false
     ;(async () => {
       const leaflet = await import('leaflet')
@@ -61,15 +69,15 @@
         keyboard: false,
         zoomControl: true,
         attributionControl: false,
-      }).setView([loc.lat, loc.lng], 15)
+      }).setView([lat, lng], 15)
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(miniMap)
       const icon = L.divIcon({
-        html: `<div class="mini-pin" style="--pin:${def.color}"><span>${def.emoji}</span></div>`,
+        html: `<div class="mini-pin" style="--pin:${color}"><span>${emoji}</span></div>`,
         className: 'mini-pin-wrap',
         iconSize: [30, 30],
         iconAnchor: [15, 30],
       })
-      L.marker([loc.lat, loc.lng], { icon }).addTo(miniMap)
+      L.marker([lat, lng], { icon }).addTo(miniMap)
       requestAnimationFrame(() => miniMap?.invalidateSize())
     })()
     return () => {

--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -1,3 +1,11 @@
+<script module lang="ts">
+  // Shared across every Modal instance: the currently-open modals, innermost
+  // last. Reactive so each instance can tell whether it is the top-most, which
+  // is what lets Escape dismiss only the innermost of a stack.
+  const openStack = $state<symbol[]>([])
+  let idCounter = 0
+</script>
+
 <script lang="ts">
   import type { Snippet } from 'svelte'
   import { X } from 'lucide-svelte'
@@ -31,6 +39,26 @@
     lg: 'max-w-4xl'
   }
 
+  // Modals can stack (e.g. a note's detail opened from a thread). Register the
+  // open instances so Escape dismisses only the top-most one instead of
+  // collapsing the whole stack at once.
+  const token = Symbol('modal')
+
+  $effect(() => {
+    if (!open) return
+    openStack.push(token)
+    return () => {
+      const i = openStack.indexOf(token)
+      if (i !== -1) openStack.splice(i, 1)
+    }
+  })
+
+  let isTopMost = $derived(open && openStack[openStack.length - 1] === token)
+
+  // Unique per instance: duplicating one id across stacked modals makes screen
+  // readers announce the wrong title.
+  const titleId = `modal-title-${++idCounter}`
+
   function handleBackdrop(e: MouseEvent) {
     if (e.target === e.currentTarget) {
       onclose()
@@ -38,7 +66,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Escape') {
+    if (e.key === 'Escape' && isTopMost) {
       onclose()
     }
   }
@@ -55,7 +83,8 @@
     onkeydown={handleKeydown}
     role="dialog"
     aria-modal="true"
-    aria-labelledby="modal-title"
+    aria-label={header ? title : undefined}
+    aria-labelledby={header ? undefined : titleId}
     tabindex="-1"
   >
     <div class="bg-surface rounded-xl {sizes[size]} w-full max-h-[90vh] overflow-hidden shadow-2xl flex flex-col">
@@ -64,7 +93,7 @@
         {@render header()}
       {:else}
         <header class="shrink-0 border-b border-[var(--color-border)] p-4 flex items-center justify-between">
-          <h2 id="modal-title" class="text-lg font-bold">{title}</h2>
+          <h2 id={titleId} class="text-lg font-bold">{title}</h2>
           <IconButton icon={X} onclick={onclose} label="Close" variant="ghost" size="sm" />
         </header>
       {/if}

--- a/src/lib/firebase.test.ts
+++ b/src/lib/firebase.test.ts
@@ -33,6 +33,7 @@ vi.mock("firebase/firestore", () => ({
         return { id: "generated-id", path: `${collectionOrDb.name}/generated-id` }
     }),
     deleteDoc: vi.fn(() => Promise.resolve()),
+    deleteField: vi.fn(() => ({ __delete: true })),
     getDoc: vi.fn(() => Promise.resolve({ exists: () => false, data: () => null })),
     onSnapshot: vi.fn((_query, _callback) => {
         // Mock unsubscribe function
@@ -292,6 +293,25 @@ describe("Firebase utilities", () => {
             expect(data).toHaveProperty("Z")
             expect(data).toHaveProperty("T")
             expect(call[2]).toEqual({ merge: true })
+        })
+
+        it("converts cleared optional fields into deleteField sentinels", async () => {
+            // Firestore rejects `undefined`, and under merge:true a dropped key
+            // would keep its old remote value — so a cleared profile picture
+            // would reappear on the next sync.
+            const cleared = {
+                Z: { name: "Zed", profilePicture: undefined, noteSignature: undefined },
+            } as unknown as UserPreferencesMap
+
+            await savePreferencesToFirestore(cleared, "Z")
+
+            const data = vi.mocked(firestore.setDoc).mock.calls[0][1] as Record<string, unknown>
+            const entry = data.Z as Record<string, unknown>
+
+            expect(entry.name).toBe("Zed")
+            expect(entry.profilePicture).toEqual({ __delete: true })
+            expect(entry.noteSignature).toEqual({ __delete: true })
+            expect(Object.values(entry)).not.toContain(undefined)
         })
     })
 })

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -10,6 +10,7 @@ import {
 import {
     collection,
     deleteDoc,
+    deleteField,
     doc,
     getDoc,
     getFirestore,
@@ -108,6 +109,23 @@ export { deleteProfilePicture, uploadProfilePicture } from "./drive"
 const PREFERENCES_DOC = "preferences/shared"
 
 /**
+ * Prepare one identity's preferences for a merged write.
+ *
+ * Firestore rejects `undefined` field values outright, and because we write
+ * with `merge: true` a key that simply disappears locally would keep its old
+ * remote value — so clearing a profile picture or signature would silently come
+ * back on the next sync. Both problems are handled by turning cleared optional
+ * fields into explicit `deleteField()` sentinels.
+ */
+function preferencesForWrite(prefs: object): Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(prefs)) {
+        out[key] = value === undefined ? deleteField() : value
+    }
+    return out
+}
+
+/**
  * Persist preferences to Firestore. When `userId` is given, only that user's
  * entry is written (merge), so a device signed in as one identity can never
  * overwrite the other identity's settings. Without `userId`, the full map is
@@ -121,11 +139,14 @@ export async function savePreferencesToFirestore(
     if (userId) {
         await setDoc(
             docRef,
-            { [userId]: prefs[userId], updatedAt: serverTimestamp() },
+            { [userId]: preferencesForWrite(prefs[userId] ?? {}), updatedAt: serverTimestamp() },
             { merge: true }
         )
     } else {
-        await setDoc(docRef, { ...prefs, updatedAt: serverTimestamp() }, { merge: true })
+        const all = Object.fromEntries(
+            Object.entries(prefs).map(([id, p]) => [id, preferencesForWrite(p ?? {})])
+        )
+        await setDoc(docRef, { ...all, updatedAt: serverTimestamp() }, { merge: true })
     }
 }
 

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -4,7 +4,7 @@
   import { activeUser, displayNames, displayAbbreviations, userPreferences, mediaGridSize, type GridSize } from '$lib/stores/app'
   import type { Media, MediaStatus, MediaType, TMDBSearchResult, UserId, ProductionCompany, MediaCollection, TogethernessState } from '$lib/types'
   import { toast } from 'svelte-sonner'
-  import { getDisplayRating, hasWatched, watchTogetherness, toggleSeenBy } from '$lib/types'
+  import { getDisplayRating, hasWatched, watchTogetherness, toggleWatched } from '$lib/types'
   import { DEFAULT_ACCENT } from '$lib/accents'
   import { enrichMediaData } from '$lib/tmdb'
   import { searchGames, type WikiGameResult } from '$lib/wikipedia'
@@ -382,7 +382,7 @@
   async function toggleSeen(item: Media, user: UserId): Promise<void> {
     if (!item.id) return
     hapticSuccess()
-    await updateDocument<Media>('media', item.id, { seenBy: toggleSeenBy(item, user) }, $activeUser)
+    await updateDocument<Media>('media', item.id, toggleWatched(item, user), $activeUser)
   }
 
   function posterUrl(path: string | null | undefined, size: 'sm' | 'md' = 'sm'): string | null {

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -420,30 +420,36 @@
     document.addEventListener('click', handler)
     return () => document.removeEventListener('click', handler)
   })
+  // Bulk ops snapshot the selection up front (so it can't shift mid-flight) and
+  // issue their writes together rather than one round trip at a time.
   async function bulkArchive(): Promise<void> {
+    const ids = [...selectedIds]
+    if (ids.length === 0) return
     hapticLight()
-    for (const id of selectedIds) await updateDocument<Note>('notes', id, { archived: true }, $activeUser)
-    toast.success(`Archived ${selectedIds.size} note${selectedIds.size === 1 ? '' : 's'}`)
-    selectedIds = new Set(); selectMode = false
+    exitSelect()
+    await Promise.all(ids.map(id => updateDocument<Note>('notes', id, { archived: true }, $activeUser)))
+    toast.success(`Archived ${ids.length} note${ids.length === 1 ? '' : 's'}`)
   }
   async function bulkMarkRead(): Promise<void> {
-    for (const id of selectedIds) {
-      const n = notes.find(x => x.id === id)
-      if (n && !n.read && n.createdBy !== $activeUser) {
-        await updateDocument<Note>('notes', id, { read: true, readAt: Timestamp.now() }, $activeUser)
-      }
-    }
-    selectedIds = new Set(); selectMode = false
+    const targets = [...selectedIds]
+      .map(id => notes.find(x => x.id === id))
+      .filter((n): n is Note => !!n && !n.read && n.createdBy !== $activeUser)
+    exitSelect()
+    if (targets.length === 0) return
+    await Promise.all(targets.map(n =>
+      updateDocument<Note>('notes', n.id!, { read: true, readAt: Timestamp.now() }, $activeUser)
+    ))
   }
   function bulkDelete(): void {
-    const count = selectedIds.size
+    const ids = [...selectedIds]
+    if (ids.length === 0) return
     pendingConfirm = {
-      message: `Tear up ${count} note${count === 1 ? '' : 's'} permanently?`,
+      message: `Tear up ${ids.length} note${ids.length === 1 ? '' : 's'} permanently?`,
       onConfirm: async () => {
         pendingConfirm = null
-        for (const id of selectedIds) await deleteDocument('notes', id)
-        toast.success(`Tore up ${count} note${count === 1 ? '' : 's'}`)
-        selectedIds = new Set(); selectMode = false
+        exitSelect()
+        await Promise.all(ids.map(id => deleteDocument('notes', id)))
+        toast.success(`Tore up ${ids.length} note${ids.length === 1 ? '' : 's'}`)
       }
     }
   }
@@ -460,15 +466,25 @@
       if (n) keys.add(threadKeyOf(n))
     }
     if (keys.size < 2) { toast('Those notes are already linked'); return }
-    const members = notes.filter(n => !n.archived && keys.has(threadKeyOf(n)))
+    // Only notes with a real id can be linked (the id is the thread key), and
+    // an all-archived selection would leave nothing to root the thread on.
+    const members = notes.filter(n => !n.archived && n.id && keys.has(threadKeyOf(n)))
     const root = [...members].sort((a, b) => (a.createdAt?.toMillis?.() ?? 0) - (b.createdAt?.toMillis?.() ?? 0))[0]
-    const rootKey = root.threadId ?? root.id ?? ''
+    // Root on the earliest *live* note's own id — reusing an inherited threadId
+    // could key the stack on an archived note that never appears on the board,
+    // and would leave the root note replying to itself.
+    const rootKey = root?.id
     if (!rootKey) return
     hapticSuccess()
-    for (const m of members) {
-      if (m.id === rootKey) continue
-      await updateDocument<Note>('notes', m.id!, { threadId: rootKey, replyTo: root.id! }, $activeUser)
-    }
+    await Promise.all(
+      members.map(m => m.id === rootKey
+        // Re-root: the root may still carry an inherited threadId pointing at an
+        // archived note, which would leave it outside its own new stack.
+        ? (root.threadId && root.threadId !== rootKey
+            ? updateDocument<Note>('notes', rootKey, { threadId: rootKey, replyTo: '' }, $activeUser)
+            : Promise.resolve())
+        : updateDocument<Note>('notes', m.id!, { threadId: rootKey, replyTo: rootKey }, $activeUser))
+    )
     toast.success(`Linked ${members.length} notes into a thread`)
     selectedIds = new Set(); selectMode = false
   }
@@ -1157,7 +1173,7 @@
   {#snippet header()}
     {#if selectedNote}
       {@const tone = toneOf(selectedNote)}
-      <div class="relative modal-note-header p-6 shrink-0" style={noteVars(tone)}>
+      <div class="relative modal-note-header p-6 shrink-0" style={noteVars(tone, selectedNote.customColor)}>
         <button
           class="absolute top-2 right-2 w-11 h-11 rounded-full bg-black/10 flex items-center justify-center hover:bg-black/20 transition-colors touch-manipulation"
           onclick={closeNoteDetail}
@@ -1360,25 +1376,25 @@
     <div class="context-reacts">
       {#each REACTION_EMOJIS as emoji (emoji)}
         {@const mine = (cf.reactions?.[emoji] ?? []).includes($activeUser)}
-        <button type="button" class="react-emoji {mine ? 'is-mine' : ''}" onclick={() => toggleReaction(cf, emoji)}>{emoji}</button>
+        <button type="button" role="menuitemcheckbox" aria-checked={mine} aria-label="React {emoji}" class="react-emoji {mine ? 'is-mine' : ''}" onclick={() => toggleReaction(cf, emoji)}>{emoji}</button>
       {/each}
     </div>
     <div class="context-actions">
       {#if stackSizeOf(cf) > 1}
-        <button type="button" class="context-btn context-yarn" onclick={() => expandFromContext(cf)}>
+        <button type="button" role="menuitem" class="context-btn context-yarn" onclick={() => expandFromContext(cf)}>
           <Layers size={16} /><span>Expand stack</span><span class="yarn-badge">{stackSizeOf(cf)}</span>
         </button>
       {/if}
-      <button type="button" class="context-btn" onclick={() => { closeContext(); selectMode = false; selectedIds = new Set(); startReply(cf) }}>
+      <button type="button" role="menuitem" class="context-btn" onclick={() => { closeContext(); selectMode = false; selectedIds = new Set(); startReply(cf) }}>
         <Reply size={16} /><span>Reply</span>
       </button>
-      <button type="button" class="context-btn" onclick={() => { togglePin(cf); closeContext() }}>
+      <button type="button" role="menuitem" class="context-btn" onclick={() => { togglePin(cf); closeContext() }}>
         <Pin size={16} class={cf.pinned ? 'text-accent' : ''} /><span>{cf.pinned ? 'Unpin' : 'Pin'}</span>
       </button>
-      <button type="button" class="context-btn" onclick={() => { toggleArchive(cf); closeContext() }}>
+      <button type="button" role="menuitem" class="context-btn" onclick={() => { toggleArchive(cf); closeContext() }}>
         <Archive size={16} /><span>Archive</span>
       </button>
-      <button type="button" class="context-btn context-danger" onclick={() => { closeContext(); cf.id && removeNote(cf.id) }}>
+      <button type="button" role="menuitem" class="context-btn context-danger" onclick={() => { closeContext(); cf.id && removeNote(cf.id) }}>
         <Trash2 size={16} /><span>Delete</span>
       </button>
     </div>

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -23,7 +23,7 @@
   import { forceRepaint } from '$lib/pwa-utils'
   import { consumeQueryParam } from '$lib/stores/nav'
   import 'leaflet/dist/leaflet.css'
-  import type { Map as LeafletMap, LayerGroup, Marker } from 'leaflet'
+  import type { Map as LeafletMap, LayerGroup } from 'leaflet'
 
   // ---- Data ----
   let places = $state<Place[]>([])
@@ -40,7 +40,6 @@
   // Only reveal the map once its first tiles have painted, so we don't flash a
   // bright half-loaded map (especially jarring in dark mode).
   let tilesLoaded = $state(false)
-  const markerById = new Map<string, Marker>()
 
   // ---- UI state ----
   let showForm = $state(false)
@@ -188,7 +187,6 @@
   function rebuildSavedMarkers(): void {
     if (!L || !map || !savedLayer) return
     savedLayer.clearLayers()
-    markerById.clear()
     for (const place of mapPlaces) {
       if (!place.location || !place.id) continue
       const icon = L.divIcon({
@@ -201,7 +199,6 @@
       const marker = L.marker([place.location.lat, place.location.lng], { icon, title: place.name })
       marker.on('click', () => { selectedPlace = place })
       marker.addTo(savedLayer)
-      markerById.set(place.id, marker)
     }
   }
 
@@ -257,15 +254,23 @@
     return { west: b.getWest(), south: b.getSouth(), east: b.getEast(), north: b.getNorth() }
   }
 
+  // Nominatim is rate-limited (~1.5s), so a search can still be in flight after
+  // the panel is closed or another search starts. Stamp each run and ignore any
+  // response that is no longer the current one, otherwise a late result drops a
+  // stray pin and flies the map somewhere the user didn't ask for.
+  let discoverRunId = 0
+
   async function runDiscovery(): Promise<void> {
     const bounds = currentBounds()
     if (!bounds) return
+    const runId = ++discoverRunId
     discoverLoading = true
     discoverError = null
     discoverCandidates = []
     discoverIndex = 0
     try {
       const found = await discoverInBounds(CATEGORY_QUERY[discoverCategory], bounds, 12)
+      if (runId !== discoverRunId || !discoverOpen) return
       // Drop candidates that essentially match a place we already have.
       const known = new Set(places.map(p => p.name.toLowerCase()))
       discoverCandidates = found.filter(c => !known.has(c.name.toLowerCase()))
@@ -273,10 +278,13 @@
         discoverError = `No new ${categoryDef(discoverCategory).label.toLowerCase()} spots in view — pan the map and try again.`
       }
     } catch (e) {
+      if (runId !== discoverRunId || !discoverOpen) return
       discoverError = e instanceof Error ? e.message : 'Discovery failed'
     } finally {
-      discoverLoading = false
-      renderDiscoverPin()
+      if (runId === discoverRunId) {
+        discoverLoading = false
+        if (discoverOpen) renderDiscoverPin()
+      }
     }
   }
 
@@ -309,6 +317,8 @@
 
   function closeDiscovery(): void {
     discoverOpen = false
+    discoverRunId++ // invalidate any in-flight search
+    discoverLoading = false
     discoverCandidates = []
     discoverIndex = 0
     discoverError = null

--- a/src/lib/pages/home/HomeGreeting.svelte
+++ b/src/lib/pages/home/HomeGreeting.svelte
@@ -15,8 +15,19 @@
     return { greeting: 'Good night', icon: Moon }
   }
 
-  let today = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
-  let part = $derived(partOfDay())
+  // Re-evaluated on a timer: this is a PWA that people leave open, so an
+  // install left running overnight would otherwise still greet "Good evening"
+  // and show yesterday's date.
+  let now = $state(Date.now())
+  $effect(() => {
+    const id = setInterval(() => { now = Date.now() }, 60_000)
+    return () => clearInterval(id)
+  })
+
+  let today = $derived(
+    new Date(now).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
+  )
+  let part = $derived((() => { void now; return partOfDay() })())
 </script>
 
 <div class="hearth">

--- a/src/lib/tabs.ts
+++ b/src/lib/tabs.ts
@@ -4,7 +4,7 @@
 // any remainder (plus unchosen destinations) spill into the "More" sheet.
 
 import type { ComponentType } from "svelte"
-import { Home, Library, StickyNote, MapPin, Video, Settings } from "lucide-svelte"
+import { Home, Library, StickyNote, MapPin, Video, Settings, Heart } from "lucide-svelte"
 import { DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN, MAX_TABS_SHOWN } from "./tabsConfig"
 
 export { DEFAULT_BOTTOM_TABS, DEFAULT_MAX_TABS_SHOWN, MAX_TABS_SHOWN }
@@ -17,7 +17,9 @@ export interface TabDef {
     matchPrefix?: string // active when the route starts with this (e.g. /library)
 }
 
-// Search folded into Media discovery; Profiles moved into the identity pill.
+// Search folded into Media discovery. Profiles primarily lives in the identity
+// pill, but stays registered here so it remains reachable (via "More", or by
+// adding it to the bar) when the pill is switched off in Settings.
 export const TAB_DEFS: TabDef[] = [
     { key: "home", label: "Home", path: "/", icon: Home },
     { key: "media", label: "Media", path: "/library/movies", icon: Library, matchPrefix: "/library" },
@@ -25,6 +27,7 @@ export const TAB_DEFS: TabDef[] = [
     { key: "places", label: "Places", path: "/places", icon: MapPin },
     { key: "videos", label: "Videos", path: "/videos", icon: Video },
     { key: "settings", label: "Settings", path: "/settings", icon: Settings },
+    { key: "profiles", label: "Keepsakes", path: "/profiles", icon: Heart },
 ]
 
 export function tabDef(key: string): TabDef | undefined {

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -22,7 +22,8 @@ import {
     getBudgetLabel,
     hasWatched,
     watchTogetherness,
-    toggleSeenBy,
+    setWatched,
+    toggleWatched,
     type GeoLocation,
 } from "./types"
 
@@ -705,6 +706,14 @@ describe("Type definitions", () => {
             it("is false for an untouched title", () => {
                 expect(hasWatched(media({}), "Z")).toBe(false)
             })
+            it("lets an explicit un-watched mark override an inferred rating", () => {
+                const m = media({ ratings: { Z: 4, T: null }, unseenBy: ["Z"] })
+                expect(hasWatched(m, "Z")).toBe(false)
+            })
+            it("prefers an explicit watched mark over an explicit un-watched one", () => {
+                const m = media({ seenBy: ["Z"], unseenBy: ["Z"] })
+                expect(hasWatched(m, "Z")).toBe(true)
+            })
         })
 
         describe("watchTogetherness", () => {
@@ -721,15 +730,43 @@ describe("Type definitions", () => {
             })
         })
 
-        describe("toggleSeenBy", () => {
-            it("adds a user not present", () => {
-                expect(toggleSeenBy(media({ seenBy: [] }), "Z")).toEqual(["Z"])
+        describe("setWatched", () => {
+            it("marks watched and clears any un-watched record", () => {
+                expect(setWatched(media({ unseenBy: ["Z"] }), "Z", true))
+                    .toEqual({ seenBy: ["Z"], unseenBy: [] })
             })
-            it("removes a user present, preserving canonical order", () => {
-                expect(toggleSeenBy(media({ seenBy: ["Z", "T"] }), "Z")).toEqual(["T"])
+            it("marks un-watched and records the negative", () => {
+                expect(setWatched(media({ seenBy: ["Z", "T"] }), "Z", false))
+                    .toEqual({ seenBy: ["T"], unseenBy: ["Z"] })
             })
-            it("handles missing seenBy", () => {
-                expect(toggleSeenBy(media({}), "T")).toEqual(["T"])
+            it("preserves canonical user order", () => {
+                expect(setWatched(media({ seenBy: ["T"] }), "Z", true).seenBy).toEqual(["Z", "T"])
+            })
+            it("leaves the other partner untouched", () => {
+                const out = setWatched(media({ ratings: { Z: null, T: 5 } }), "Z", false)
+                expect(out.unseenBy).toEqual(["Z"])
+                expect(hasWatched(media({ ratings: { Z: null, T: 5 } }), "T")).toBe(true)
+            })
+        })
+
+        describe("toggleWatched", () => {
+            it("un-marks a title that was only inferred watched from a rating", () => {
+                // Regression: toggling used to be a no-op because the rating
+                // kept inferring "watched" after removal from seenBy.
+                const m = media({ ratings: { Z: 4, T: null } })
+                expect(hasWatched(m, "Z")).toBe(true)
+                const next = toggleWatched(m, "Z")
+                expect(next.unseenBy).toEqual(["Z"])
+                expect(hasWatched(media({ ...m, ...next }), "Z")).toBe(false)
+            })
+            it("round-trips back to watched", () => {
+                const m = media({ ratings: { Z: 4, T: null } })
+                const off = toggleWatched(m, "Z")
+                const back = toggleWatched(media({ ...m, ...off }), "Z")
+                expect(hasWatched(media({ ...m, ...back }), "Z")).toBe(true)
+            })
+            it("marks an untouched title watched", () => {
+                expect(toggleWatched(media({}), "T")).toEqual({ seenBy: ["T"], unseenBy: [] })
             })
         })
     })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -143,7 +143,8 @@ export interface Media extends BaseDocument {
     status: MediaStatus
     rating: number | null // Legacy field for backward compatibility
     ratings?: Record<UserId, number | null> // Per-user ratings
-    seenBy?: UserId[] // Which partners have personally watched this (couple watch-state)
+    seenBy?: UserId[] // Partners who have personally watched this (couple watch-state)
+    unseenBy?: UserId[] // Partners explicitly marked NOT watched; suppresses rating-based inference
     notes: string
     progress?: MediaProgress
     // Metadata fields
@@ -209,9 +210,43 @@ export type TogethernessState = "both" | "mine" | "theirs" | "none"
  * intentionally ignored here since it isn't attributable to one partner.
  */
 export function hasWatched(media: Media, user: UserId): boolean {
+    // Explicit marks win over inference, in both directions.
     if (media.seenBy?.includes(user)) return true
+    if (media.unseenBy?.includes(user)) return false
     const r = media.ratings?.[user]
     return r !== null && r !== undefined
+}
+
+/** The explicit watch flags for a media item, as stored. */
+export interface WatchFlags {
+    seenBy: UserId[]
+    unseenBy: UserId[]
+}
+
+/**
+ * Set a partner's watched state explicitly. Marking un-watched records a
+ * negative so a pre-existing rating can't keep inferring "watched" — otherwise
+ * the toggle would be a no-op for anything either partner has rated.
+ */
+export function setWatched(media: Media, user: UserId, watched: boolean): WatchFlags {
+    const seen = new Set(media.seenBy ?? [])
+    const unseen = new Set(media.unseenBy ?? [])
+    if (watched) {
+        seen.add(user)
+        unseen.delete(user)
+    } else {
+        seen.delete(user)
+        unseen.add(user)
+    }
+    return {
+        seenBy: ALL_USER_IDS.filter(u => seen.has(u)),
+        unseenBy: ALL_USER_IDS.filter(u => unseen.has(u)),
+    }
+}
+
+/** Flip a partner's watched state, honouring rating-based inference. */
+export function toggleWatched(media: Media, user: UserId): WatchFlags {
+    return setWatched(media, user, !hasWatched(media, user))
 }
 
 /** Classify a title by who of the pair has seen it, from `viewer`'s POV. */
@@ -224,13 +259,6 @@ export function watchTogetherness(media: Media, viewer: UserId, partner: UserId)
     return "none"
 }
 
-/** Toggle a partner's personal "watched" flag, returning the next seenBy list. */
-export function toggleSeenBy(media: Media, user: UserId): UserId[] {
-    const set = new Set(media.seenBy ?? [])
-    if (set.has(user)) set.delete(user)
-    else set.add(user)
-    return ALL_USER_IDS.filter(u => set.has(u))
-}
 
 export type PlaceCategory =
     | "restaurant"


### PR DESCRIPTION
Child PR **S** — cleanup pass, part 2: an adversarial audit of the entire branch vs `main`, and fixes for what it found. Two of these are bugs in features shipped earlier *this session*.

## Correctness

| Bug | Failure it caused |
|---|---|
| **"Watched by" was a permanent no-op for rated titles** | `hasWatched()` infers "watched" from a per-user rating, but the toggle only touched `seenBy` — so un-marking never took effect, and the Between Us lens could never classify a rated title as "waiting on" anyone. Explicit marks now win in both directions via an `unseenBy` negative list (`setWatched`/`toggleWatched`), with a regression test for the toggle round-trip. |
| **Cleared preferences came back; manual Save always failed** | Writes use `merge: true`, so a cleared optional field (profile picture, note signature, board colour) kept its old remote value and reappeared on the next sync. Those same keys were also sent as literal `undefined`, which Firestore rejects — meaning the new Save button errored on a default install. Both fixed by writing cleared fields as explicit `deleteField()` sentinels. |
| **Escape closed a whole modal stack at once** | Every open `Modal` listened on `window`, so Escape in a note detail opened from a stack closed the thread modal too. Modals now register in a shared stack; only the top-most handles Escape. |
| **Profiles unreachable with the pill hidden** | Profiles was removed from the sidebar and tab registry when it moved into the identity pill — but Settings can hide the pill, leaving `/profiles` with zero entry points. Re-registered as a tab so it's reachable via "More". |
| **Stray discovery pin after closing the panel** | Nominatim is rate-limited ~1.5s, so a search resolving after close dropped a pin and flew the map away. Runs are stamped; late results are discarded. |
| **`bulkLink` could root a stack on an archived note** | The stack was keyed on an id that never appears on the board, and the root ended up replying to itself. Now roots on the earliest *live* note and re-roots it if it carried a stale `threadId`. |

## Perf / lifecycle
- **Place mini-map rebuilt on every Firestore snapshot** — its effect depended on the whole `place` object, which the parent reassigns per snapshot, so zooming then blurring the notes field reset the map and re-fetched tiles. Now depends on coordinates + pin appearance only.
- **Identity pill fly-out** direction is recomputed while dragging, so dragging an open panel across the viewport midpoint no longer leaves it off-screen.
- **Bulk note actions** snapshot the selection and issue writes concurrently instead of one sequential round trip each, and exit select mode immediately.

## Cleanup / a11y
- Notes' detail header ignored a note's custom paper colour.
- Context-menu children carry proper `menuitem` roles; modals get unique title ids.
- Home greeting/date refresh on a timer (a PWA left open overnight kept showing yesterday's date and "Good evening" at 2am).
- Removed the write-only marker map in Places and the unused `withHsl` helper.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — **326 / 326** (7 new)

Audit findings deliberately **not** actioned (low value / risk of churn): context menu doesn't follow board scroll; `autoCenter` is a one-shot rather than a live mode; legacy note colours don't preselect a tone swatch when editing pre-migration notes. Happy to pick any of these up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_