### PR TITLE
[T] Stop the global 44px touch minimum from distorting compact controls

### DIFF
--- a/src/lib/components/MediaDetailModal.svelte
+++ b/src/lib/components/MediaDetailModal.svelte
@@ -229,21 +229,22 @@
           
           <div class="flex-1 min-w-[160px]">
             <span class="block text-xs text-slate-500 dark:text-slate-400 mb-1">Watched by</span>
-            <div class="flex flex-col gap-1.5">
+            <div class="flex flex-wrap gap-1.5">
               {#each coupleUsers as u}
                 {@const seen = hasWatched(media, u)}
+                {@const accent = $userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}
                 <button
                   type="button"
-                  class="flex items-center gap-2 px-2 py-1.5 rounded-xl text-sm font-medium transition-colors touch-manipulation border {seen ? 'border-transparent text-white' : 'border-[var(--color-border)] text-slate-500 dark:text-slate-400'}"
-                  style={seen ? `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}` : ''}
+                  class="watch-chip touch-sm {seen ? 'is-seen' : ''}"
+                  style={seen ? `background-color:${accent};border-color:${accent}` : ''}
                   onclick={() => toggleSeen(u)}
                   aria-pressed={seen}
+                  title="{getDisplayNameForUser(u)} {seen ? 'has watched this' : 'has not watched this'}"
                 >
-                  <span class="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 {seen ? 'bg-white/25' : ''}" style={seen ? '' : `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}20;color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}`}>
+                  <span class="watch-chip__badge" style={seen ? '' : `background-color:${accent}22;color:${accent}`}>
                     {$displayAbbreviations[u]}
                   </span>
                   <span class="truncate">{getDisplayNameForUser(u)}</span>
-                  <span class="ml-auto text-xs opacity-80">{seen ? 'Watched' : 'Mark'}</span>
                 </button>
               {/each}
             </div>
@@ -452,3 +453,41 @@
     </div>
   </Modal>
 {/if}
+
+<style>
+  /* Compact watched-by chips. `touch-sm` opts out of the global 44px
+     coarse-pointer minimum, which stretched these into tall slabs; the chip
+     keeps a comfortable 32px target without the wasted vertical padding. */
+  .watch-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 2rem;
+    padding: 0.2rem 0.6rem 0.2rem 0.25rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-text-muted, #57534e);
+    max-width: 100%;
+    transition: background-color 120ms, border-color 120ms, color 120ms;
+  }
+  .watch-chip.is-seen { color: #fff; }
+  .watch-chip__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    font-size: 0.62rem;
+    font-weight: 800;
+    line-height: 1;
+  }
+  .watch-chip.is-seen .watch-chip__badge {
+    background: rgba(255, 255, 255, 0.28);
+    color: #fff;
+  }
+</style>

--- a/src/lib/pages/Library.svelte
+++ b/src/lib/pages/Library.svelte
@@ -872,7 +872,7 @@
                   {@const seen = hasWatched(item, u)}
                   <button
                     type="button"
-                    class="seen-dot {seen ? 'is-seen' : ''}"
+                    class="seen-dot touch-sm {seen ? 'is-seen' : ''}"
                     style={seen ? `background-color:${$userPreferences[u]?.accentColor ?? DEFAULT_ACCENT}` : ''}
                     onclick={(e) => { e.stopPropagation(); toggleSeen(item, u) }}
                     aria-pressed={seen}
@@ -950,16 +950,23 @@
   .lens-chip.is-on .lens-count { background: rgba(255,255,255,0.25); }
 
   /* ===== Per-card seen-by faces ===== */
+  /* Compact, strictly circular. `touch-sm` opts out of the global 44px
+     coarse-pointer minimum, which would otherwise stretch these into ovals. */
   .seen-dot {
     position: relative;
-    width: 1.4rem;
-    height: 1.4rem;
+    flex: 0 0 auto;
+    width: 1.35rem;
+    height: 1.35rem;
+    min-height: 0;
+    padding: 0;
+    aspect-ratio: 1;
     border-radius: 50%;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.6rem;
+    font-size: 0.58rem;
     font-weight: 800;
+    line-height: 1;
     color: var(--color-text-hint, #78716c);
     background: transparent;
     border: 1.5px dashed var(--color-border);

--- a/src/lib/pages/Notes.svelte
+++ b/src/lib/pages/Notes.svelte
@@ -1434,7 +1434,7 @@
             <div class="flex items-center gap-1.5">
               <span class="thread-time">{getRelativeTime(n.createdAt)}</span>
               {#if canUnlink(n)}
-                <button type="button" class="thread-unlink" onclick={(e) => { e.stopPropagation(); unlinkNote(n) }} aria-label="Unlink from thread" title="Unlink from thread">
+                <button type="button" class="thread-unlink touch-sm" onclick={(e) => { e.stopPropagation(); unlinkNote(n) }} aria-label="Unlink from thread" title="Unlink from thread">
                   <Unlink size={13} />
                 </button>
               {/if}
@@ -2517,7 +2517,9 @@
   .thread-time { font-size: 0.65rem; color: var(--note-ink); opacity: 0.5; }
   .thread-unlink {
     display: inline-flex; align-items: center; justify-content: center;
-    width: 1.5rem; height: 1.5rem; border-radius: 50%;
+    flex: 0 0 auto;
+    width: 1.5rem; height: 1.5rem; min-height: 0; padding: 0;
+    aspect-ratio: 1; border-radius: 50%;
     color: var(--note-ink); opacity: 0.5;
     transition: opacity 120ms, background 120ms;
   }

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -531,10 +531,10 @@
                 · {discoverIndex + 1}/{discoverCandidates.length}
               </div>
             </div>
-            <button type="button" class="disc-btn" onclick={rerollDiscovery} title="Show another" aria-label="Reroll">
+            <button type="button" class="disc-btn touch-sm" onclick={rerollDiscovery} title="Show another" aria-label="Reroll">
               <RotateCw size={16} />
             </button>
-            <button type="button" class="disc-btn disc-btn--add" onclick={addCandidate} title="Add this place" aria-label="Add">
+            <button type="button" class="disc-btn disc-btn--add touch-sm" onclick={addCandidate} title="Add this place" aria-label="Add">
               <Plus size={16} />
             </button>
           </div>
@@ -807,7 +807,8 @@
   }
   .disc-btn {
     flex-shrink: 0;
-    width: 38px; height: 38px;
+    width: 38px; height: 38px; min-height: 0; padding: 0;
+    aspect-ratio: 1;
     display: flex; align-items: center; justify-content: center;
     border-radius: 0.6rem;
     border: 1px solid var(--color-border);


### PR DESCRIPTION
Child PR **T** — fixes the stretched watch indicators, and the class of bug behind them.

**Root cause:** the coarse-pointer rule in `app.css` applies `min-height: 44px` to *every* `button`, which silently overrides any control designed smaller. For circular or square controls the height grows but the width doesn't — so they render as stretched ovals/slabs. That's exactly what happened to the per-user watch indicators.

- **Library seen-by dots** — opt out via the existing `touch-sm` escape hatch and lock them to a true circle (`aspect-ratio`, zero padding, `min-height: 0`).
- **Media detail "Watched by"** — the stacked full-width rows were mostly vertical padding. Rebuilt as compact **side-by-side chips** (32px target, tight padding) that keep each identity's accent colour and read far better on a phone.
- Swept for the same defect elsewhere and fixed two more: the thread **unlink** button (24px circle) and the Places discovery **reroll/add** buttons (38px squares).

Left alone deliberately: the pill/rect controls (rail buttons, view segments, bulk bar, tray chips) also get bumped to 44px, but they aren't *distorted* by it — only comfortably tall — so shrinking them would trade a real tappability win for nothing.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — 326 / 326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_