### PR TITLE
[U] Fix the blank dark map and the unreachable identity fly-out

### DIFF
--- a/src/lib/components/BottomTabBar.svelte
+++ b/src/lib/components/BottomTabBar.svelte
@@ -19,10 +19,17 @@
   let chosenTabs = $derived(resolveTabs($currentPreferences?.bottomTabs))
   let maxShown = $derived(clampMaxTabsShown($currentPreferences?.maxTabsShown))
   let primaryTabs = $derived(chosenTabs.slice(0, maxShown))
+  // Keepsakes lives in the identity pill's fly-out, so it's only surfaced as a
+  // navigable destination when that pill is switched off — otherwise it would
+  // add a redundant entry (and force a "More" tab) for a place you can already
+  // reach. It still appears if the user explicitly picks it for the bar.
+  let pillHidden = $derived(($currentPreferences?.showIdentityPill ?? true) === false)
   let moreItems = $derived.by(() => {
     const shown = new Set(primaryTabs.map(t => t.key))
     const overflow = chosenTabs.slice(maxShown)
-    const unchosen = TAB_DEFS.filter(t => !chosenTabs.some(c => c.key === t.key))
+    const unchosen = TAB_DEFS.filter(t =>
+      !chosenTabs.some(c => c.key === t.key) && (t.key !== 'profiles' || pillHidden)
+    )
     return [...overflow, ...unchosen].filter(t => !shown.has(t.key))
   })
 

--- a/src/lib/components/IdentityPill.svelte
+++ b/src/lib/components/IdentityPill.svelte
@@ -27,7 +27,7 @@
   let grabDY = 0
   let startX = 0
   let startY = 0
-  let justDragged = false
+  let dragEndedAt = 0
 
   onMount(() => {
     try {
@@ -70,7 +70,10 @@
     startY = e.clientY
     dragging = false
     pointerId = e.pointerId
-    pillEl.setPointerCapture(e.pointerId)
+    // NB: capture is deliberately NOT taken here. Capturing on pointerdown
+    // retargets the follow-up click to the capturing element, so the inner
+    // button never receives it and a plain tap could never open the fly-out.
+    // Capture is taken below, once a drag actually starts.
   }
 
   function onPointerMove(e: PointerEvent): void {
@@ -80,6 +83,9 @@
     if (!dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
       dragging = true
       hapticLight()
+      // Now that this is a drag rather than a tap, take the pointer so the
+      // gesture keeps tracking even if it leaves the pill.
+      try { pillEl.setPointerCapture(e.pointerId) } catch { /* not capturable */ }
     }
     if (dragging) {
       e.preventDefault()
@@ -102,8 +108,9 @@
     pointerId = null
     if (dragging) {
       // Suppress the click that follows a drag so it doesn't toggle/select.
-      justDragged = true
-      setTimeout(() => { justDragged = false }, 0)
+      // Timestamp rather than a 0ms timer: on touch the click can land in a
+      // later task, by which point a timer-cleared flag would already be gone.
+      dragEndedAt = Date.now()
       try {
         if (pos) localStorage.setItem(STORAGE_KEY, JSON.stringify(pos))
       } catch (err) {
@@ -115,14 +122,14 @@
 
   function toggle(e: MouseEvent): void {
     e.stopPropagation()
-    if (justDragged) return
+    if (Date.now() - dragEndedAt < 400) return
     if (!isExpanded) computePlacement()
     isExpanded = !isExpanded
   }
 
   function selectUser(e: MouseEvent, userId: UserId): void {
     e.stopPropagation()
-    if (justDragged) return
+    if (Date.now() - dragEndedAt < 400) return
     hapticLight()
     activeUser.set(userId)
     isExpanded = false
@@ -130,7 +137,7 @@
 
   function goProfiles(e: MouseEvent, view: 'mine' | 'theirs'): void {
     e.stopPropagation()
-    if (justDragged) return
+    if (Date.now() - dragEndedAt < 400) return
     hapticLight()
     navigate(`/profiles?view=${view}`)
     isExpanded = false

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,6 +4,7 @@
   import { hapticLight } from '$lib/haptics'
   import { getIOSCompatibleImageUrl } from '$lib/ios-images'
   import {
+    Heart,
     Library,
     Film,
     Tv,
@@ -112,12 +113,17 @@
     return `translateX(-${clampedDiff}px)`
   })
 
-  const navItems = [
+  // Keepsakes normally lives in the identity pill's fly-out; surface it here
+  // only when that pill is switched off, so it never becomes unreachable.
+  let navItems = $derived([
     { path: '/', label: 'Home', icon: Home },
     { path: '/videos', label: 'Videos', icon: Video },
     { path: '/notes', label: 'Notes', icon: StickyNote },
     { path: '/places', label: 'Places', icon: MapPin },
-  ]
+    ...(($currentPreferences?.showIdentityPill ?? true) === false
+      ? [{ path: '/profiles', label: 'Keepsakes', icon: Heart }]
+      : []),
+  ])
 
   const libraryItems = [
     { path: '/library/movies', label: 'Movies', icon: Film },

--- a/src/lib/pages/Places.svelte
+++ b/src/lib/pages/Places.svelte
@@ -131,13 +131,17 @@
         : [39.5, -98.35] // continental US fallback
       const zoom = start ? 13 : 4
 
-      map = L.map(mapEl, { zoomControl: true, attributionControl: true, fadeAnimation: false }).setView(center, zoom)
+      map = L.map(mapEl, { zoomControl: true, attributionControl: true }).setView(center, zoom)
       const tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap',
       }).addTo(map)
       // Reveal once the first batch of tiles has loaded; fall back after a
       // moment so an offline/slow tile server can't leave it hidden forever.
+      // Reveal on the first painted tile as well as the full batch: if any tile
+      // 404s or a request stalls, `load` may never fire and the map would sit
+      // behind the cover until the fallback timer.
+      tiles.once('tileload', () => { tilesLoaded = true })
       tiles.once('load', () => { tilesLoaded = true })
       tileFallbackTimer = setTimeout(() => { tilesLoaded = true }, 2500)
       savedLayer = L.layerGroup().addTo(map)
@@ -493,12 +497,10 @@
 
   <!-- Map -->
   <div class="map-frame mb-3">
-    <div class="map-canvas {tilesLoaded ? 'is-ready' : ''}" bind:this={mapEl}></div>
-    {#if !tilesLoaded}
-      <div class="map-loading">
-        <div class="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin"></div>
-      </div>
-    {/if}
+    <div class="map-canvas" bind:this={mapEl}></div>
+    <div class="map-loading {tilesLoaded ? 'is-done' : ''}" aria-hidden={tilesLoaded}>
+      <div class="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin"></div>
+    </div>
 
     <!-- Discovery overlay -->
     {#if discoverOpen}
@@ -697,14 +699,7 @@
     border: 1.5px solid color-mix(in srgb, var(--color-accent) 22%, #b7a381);
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.15), 0 10px 26px rgba(70,50,25,0.16);
   }
-  .map-canvas {
-    position: absolute;
-    inset: 0;
-    background: #ece3d2;
-    opacity: 0;
-    transition: opacity 260ms ease;
-  }
-  .map-canvas.is-ready { opacity: 1; }
+  .map-canvas { position: absolute; inset: 0; background: #ece3d2; }
   :global(.dark) .map-canvas { background: #26221c; }
   /* Leaflet paints its own container background behind the tiles. */
   .map-frame :global(.leaflet-container) { background: #ece3d2; }
@@ -732,11 +727,15 @@
     background: radial-gradient(120% 120% at 50% 40%, transparent 62%, rgba(0,0,0,0.4) 100%);
     mix-blend-mode: normal;
   }
+  /* Opaque cover that hides the half-painted map, then fades away. Fading the
+     cover (not the map) keeps Leaflet's own tile opacity handling untouched. */
   .map-loading {
     position: absolute; inset: 0; z-index: 500;
     display: flex; align-items: center; justify-content: center;
     background: #ece3d2;
+    transition: opacity 260ms ease;
   }
+  .map-loading.is-done { opacity: 0; pointer-events: none; }
   :global(.dark) .map-loading { background: #2a2620; }
 
   /* ===== Map pins (divIcon) ===== */


### PR DESCRIPTION
Child PR **U** — two regressions I introduced, plus the tab annoyance.

### Map was a dark square
Your read was close — it wasn't inverted logic, it was the *mechanism*. The flash fix faded the **map container itself** (`opacity: 0 → 1`) and set `fadeAnimation: false`; both fight Leaflet's own per-tile opacity handling, so the container's dark base colour showed with no tiles ever painting over it.

- The **cover** now fades away instead; the map container's opacity is never touched, and `fadeAnimation` is back on.
- Reveal also fires on the **first painted tile**, not only the whole-batch `load` — so one stalled or 404ing tile can't keep the map hidden behind the cover.

### Identity fly-out never opened
The root element took **pointer capture on `pointerdown`**, before knowing whether the gesture was a tap or a drag. Capture retargets the follow-up `click` to the capturing element, so the inner button never received it — tapping the pill could never open the panel.

- Capture is now taken only once a drag **actually starts**, leaving taps as ordinary clicks.
- Also replaced the `setTimeout(…, 0)` that suppressed the post-drag click with a timestamp check: on touch the click can land in a later task, by which point the timer had already cleared the flag (the audit flagged this as suspect; this makes it timing-independent).

### No forced extra tab
Keepsakes is reachable from the pill, so it's no longer offered as an extra **More** destination while the pill is enabled. It appears in the tab bar / sidebar only when the pill is switched **off** — or if you explicitly add it to the bar. That keeps it from becoming unreachable without duplicating a route that already has a home.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — 326 / 326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_