### PR TITLE
[V] Fix app freeze from a self-triggering modal effect

### DIFF
--- a/src/lib/components/ui/Modal.svelte
+++ b/src/lib/components/ui/Modal.svelte
@@ -1,8 +1,11 @@
 <script module lang="ts">
   // Shared across every Modal instance: the currently-open modals, innermost
-  // last. Reactive so each instance can tell whether it is the top-most, which
-  // is what lets Escape dismiss only the innermost of a stack.
-  const openStack = $state<symbol[]>([])
+  // last. The array itself is deliberately NOT reactive — mutating a $state
+  // array from inside an $effect makes that effect depend on state it writes,
+  // which self-triggers into an infinite loop. Instead the top of the stack is
+  // published through one write-only reactive signal that instances read.
+  const openStack: symbol[] = []
+  let topToken = $state<symbol | null>(null)
   let idCounter = 0
 </script>
 
@@ -47,13 +50,15 @@
   $effect(() => {
     if (!open) return
     openStack.push(token)
+    topToken = token
     return () => {
       const i = openStack.indexOf(token)
       if (i !== -1) openStack.splice(i, 1)
+      topToken = openStack.length > 0 ? openStack[openStack.length - 1] : null
     }
   })
 
-  let isTopMost = $derived(open && openStack[openStack.length - 1] === token)
+  let isTopMost = $derived(open && topToken === token)
 
   // Unique per instance: duplicating one id across stacked modals makes screen
   // readers announce the wrong title.


### PR DESCRIPTION
Child PR **V** — fixes the freeze. You were right that it was recursion, though the trigger wasn't the ratings code itself.

**Cause:** the modal-stack registration I added in **#91** kept its stack in a `$state` array and did `openStack.push(token)` *inside an `$effect`*. Array mutation methods read the array's own internals, so the effect took a dependency on the very state it was mutating — and re-ran itself without end. Any state change while a modal was open (changing a rating in the detail modal being the obvious one) kicked off an unbreakable loop. Consistently reproducible, exactly as you saw.

**Fix:** the stack is now a plain, non-reactive array, and the top of the stack is published through a single **write-only** reactive signal that instances read to decide whether they own Escape. Same stacked-Escape behaviour, no self-dependency.

I also swept the whole branch for the same pattern — a reactive collection mutated inside an effect — and this was the only occurrence.

## Verification
- `bun run check` — 0 / 0 · `bun run build` — ok · `bun run test:run` — 326 / 326

A broader performance + reactivity audit is running; anything it turns up lands before the parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L75W8xxQVUJFRs38AxuXem)_